### PR TITLE
Fix temporary files not being cleaned up on NFS

### DIFF
--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -579,7 +579,7 @@ sub is_perl_file
 
     return if -l $file;
     return unless -f $file;
-    return if any { /^\./ } grep { length } File::Spec->splitdir($file);
+    return if any { /^\.pls-tmp/ } grep { length } File::Spec->splitdir($file);
     return if $file =~ /\.t$/;
 
     return 1 if $file =~ /\.p[lm]$/;

--- a/server/lib/PLS/Server/Request/Diagnostics/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/Diagnostics/PublishDiagnostics.pm
@@ -96,7 +96,7 @@ sub get_compilation_errors
 
     if (ref $source eq 'SCALAR')
     {
-        $temp_dir = eval { File::Temp->newdir(CLEANUP => 0, TEMPLATE => '.XXXXXXXXXX', DIR => $dir) };
+        $temp_dir = eval { File::Temp->newdir(CLEANUP => 0, TEMPLATE => '.pls-tmp-XXXXXXXXXX', DIR => $dir) };
         $temp_dir = eval { File::Temp->newdir(CLEANUP => 0) } if (ref $temp_dir ne 'File::Temp::Dir');
 
         $future->on_done(sub { File::Path::remove_tree($temp_dir->dirname) });


### PR DESCRIPTION
Fixes #60 

* Restricts use of temporary files to `perl -c`, which restricts the lifetime of the temporary file, and only requires opening the file twice. Linting now just uses the source code directly
* Renames the temporary directory used for temporary files used for syntax checking (now starts with .pls-tmp) so that it can be ignored more easily.