### PR TITLE
Compatibility with BBEdit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .pls_cache
 .pls-tmp-*
 .vscode
+.DS_Store

--- a/server/MANIFEST
+++ b/server/MANIFEST
@@ -42,6 +42,7 @@ lib/PLS/Server/Response/Cancelled.pm
 lib/PLS/Server/Response/Hover.pm
 lib/PLS/Server/Response/Resolve.pm
 lib/PLS/Server/Response/Location.pm
+lib/PLS/Server/Response/Shutdown.pm
 lib/PLS/Server/Message.pm
 lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
 lib/PLS/Server/Request/Workspace/DidChangeConfiguration.pm
@@ -50,6 +51,8 @@ lib/PLS/Server/Request/Workspace/ApplyEdit.pm
 lib/PLS/Server/Request/Workspace/Configuration.pm
 lib/PLS/Server/Request/Client/RegisterCapability.pm
 lib/PLS/Server/Request/CancelRequest.pm
+lib/PLS/Server/Request/Shutdown.pm
+lib/PLS/Server/Request/Exit.pm
 lib/PLS/Server/Request/Initialized.pm
 lib/PLS/Server/Request/CompletionItem/Resolve.pm
 lib/PLS/Server/Request/Factory.pm

--- a/server/lib/JJ.pm
+++ b/server/lib/JJ.pm
@@ -1,0 +1,31 @@
+package JJ;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+our $VERSION = '0.1';
+
+=head1 NAME
+
+JJ
+
+=head1 DESCRIPTION
+
+Simple debugging helper that logs in BBEdits Logs directory.
+
+=cut
+
+sub jjlog {
+    my ( $sender, $object ) = @_;
+    my $log_file_path =
+        "~/Library/Containers/com.barebones.bbedit/Data/Library/Logs/BBEdit/perl-PLS.log";
+    open( FH, '>>', glob( $log_file_path ) ) or die $!;
+    print FH $sender . ': ' . Dumper( $object );
+    close FH;
+
+    return;
+}
+
+1;

--- a/server/lib/JJ.pm
+++ b/server/lib/JJ.pm
@@ -20,10 +20,10 @@ Simple debugging helper that logs in BBEdits Logs directory.
 sub jjlog {
     my ( $sender, $object ) = @_;
     my $log_file_path =
-        "~/Library/Containers/com.barebones.bbedit/Data/Library/Logs/BBEdit/perl-PLS.log";
-    open( FH, '>>', glob( $log_file_path ) ) or die $!;
-    print FH $sender . ': ' . Dumper( $object );
-    close FH;
+        "~/Library/Containers/com.barebones.bbedit/Data/Library/Logs/BBEdit/perl-PLS.txt";
+    open my $fh, '>>', glob($log_file_path) or die $!;
+    print $fh $sender . ': ' . Dumper( $object );
+    close $fh;
 
     return;
 }

--- a/server/lib/PLS/Server.pm
+++ b/server/lib/PLS/Server.pm
@@ -16,6 +16,9 @@ use Scalar::Util qw(blessed);
 use PLS::Server::Request::Factory;
 use PLS::Server::Response;
 use PLS::Server::Response::Cancelled;
+use PLS::Server::Response::Shutdown;
+
+use JJ;
 
 =head1 NAME
 
@@ -133,6 +136,8 @@ sub run
                 my $json = substr $$buffref, 0, $size, '';
                 $size = 0;
 
+                JJ::jjlog('_C', $json);
+
                 my $content = JSON::PP->new->utf8->decode($json);
 
                 $self->handle_client_message($content);
@@ -209,6 +214,9 @@ sub send_message
 
     return if (not blessed($message) or not $message->isa('PLS::Server::Message'));
     my $json   = $message->serialize();
+
+    JJ::jjlog('S_', $json);
+
     my $length = length $json;
     $self->{stream}->write("Content-Length: $length\r\n\r\n$json")->await;
 

--- a/server/lib/PLS/Server/Method/ServerMethod.pm
+++ b/server/lib/PLS/Server/Method/ServerMethod.pm
@@ -7,6 +7,8 @@ use PLS::Server::State;
 use PLS::Server::Request::Initialize;
 use PLS::Server::Request::Initialized;
 use PLS::Server::Request::CancelRequest;
+use PLS::Server::Request::Shutdown;
+use PLS::Server::Request::Exit;
 use PLS::Server::Response::ServerNotInitialized;
 
 =head1 NAME
@@ -37,6 +39,15 @@ L<PLS::Server::Request::Initialized>
 
 L<PLS::Server::Request::CancelRequest>
 
+=item shutdown - L<https://microsoft.github.io/language-server-protocol/specifications/specification-current/#shutdown>
+
+L<PLS::Server::Request::Shutdown>
+
+=item exit - L<https://microsoft.github.io/language-server-protocol/specifications/specification-current/#exit>
+
+L<PLS::Server::Request::Exit>
+
+
 =back
 
 =cut
@@ -63,6 +74,16 @@ sub get_request
     {
         return PLS::Server::Request::CancelRequest->new($request);
     }
+    
+    if ($method eq 'shutdown')
+    {
+        return PLS::Server::Request::Shutdown->new($request);
+    }
+
+    if ($method eq 'exit')
+    {
+        return PLS::Server::Request::Exit->new($request);
+    }
 
     return;
 } ## end sub get_request
@@ -73,6 +94,8 @@ sub is_server_method
 
     return 1 if ($method eq 'initialize');
     return 1 if ($method eq 'initialized');
+    return 1 if ($method eq 'shutdown');
+    return 1 if ($method eq 'exit');
     return 1 if ($method eq '$');
     return 0;
 } ## end sub is_server_method

--- a/server/lib/PLS/Server/Method/TextDocument.pm
+++ b/server/lib/PLS/Server/Method/TextDocument.pm
@@ -12,8 +12,9 @@ use PLS::Server::Request::TextDocument::DidSave;
 use PLS::Server::Request::TextDocument::DocumentSymbol;
 use PLS::Server::Request::TextDocument::Formatting;
 use PLS::Server::Request::TextDocument::Hover;
-use PLS::Server::Request::TextDocument::SignatureHelp;
+use PLS::Server::Request::TextDocument::PublishDiagnostics;
 use PLS::Server::Request::TextDocument::RangeFormatting;
+use PLS::Server::Request::TextDocument::SignatureHelp;
 
 =head1 NAME
 
@@ -125,6 +126,10 @@ sub get_request
     if ($method eq 'completion')
     {
         return PLS::Server::Request::TextDocument::Completion->new($request);
+    }
+    if ($method eq 'publishDiagnostics')
+    {
+        return PLS::Server::Request::TextDocument::PublishDiagnostics->new($request);
     }
 } ## end sub get_request
 

--- a/server/lib/PLS/Server/Method/TextDocument.pm
+++ b/server/lib/PLS/Server/Method/TextDocument.pm
@@ -127,10 +127,6 @@ sub get_request
     {
         return PLS::Server::Request::TextDocument::Completion->new($request);
     }
-    if ($method eq 'publishDiagnostics')
-    {
-        return PLS::Server::Request::TextDocument::PublishDiagnostics->new($request);
-    }
 } ## end sub get_request
 
 1;

--- a/server/lib/PLS/Server/Request/Exit.pm
+++ b/server/lib/PLS/Server/Request/Exit.pm
@@ -20,7 +20,7 @@ that the server exits.
 
 sub service
 {
-    exit 1;
+    exit 0;
 } ## end sub service
 
 1;

--- a/server/lib/PLS/Server/Request/Exit.pm
+++ b/server/lib/PLS/Server/Request/Exit.pm
@@ -1,0 +1,26 @@
+package PLS::Server::Request::Exit;
+
+use strict;
+use warnings;
+
+use parent 'PLS::Server::Request';
+
+use Scalar::Util qw(blessed);
+
+=head1 NAME
+
+PLS::Server::Request::Exit
+
+=head1 DESCRIPTION
+
+This is a notification message from the client to the server requesting
+that the server exits.
+
+=cut
+
+sub service
+{
+    exit 1;
+} ## end sub service
+
+1;

--- a/server/lib/PLS/Server/Request/Shutdown.pm
+++ b/server/lib/PLS/Server/Request/Shutdown.pm
@@ -1,0 +1,28 @@
+package PLS::Server::Request::Shutdown;
+
+use strict;
+use warnings;
+
+use parent 'PLS::Server::Request';
+
+use Scalar::Util qw(blessed);
+
+=head1 NAME
+
+PLS::Server::Request::Shutdown
+
+=head1 DESCRIPTION
+
+This is a notification message from the client to the server requesting
+that the server shuts down.
+
+=cut
+
+sub service
+{
+    my ($self) = @_;
+
+    return PLS::Server::Response::Shutdown->new($self);
+} ## end sub service
+
+1;

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -63,9 +63,9 @@ sub new
 
     if (not $args{close})
     {
-        push @futures, get_compilation_errors($source, $dir) if (defined $PLS::Server::State::CONFIG->{syntax}{enabled} and $PLS::Server::State::CONFIG->{syntax}{enabled});
-        push @futures, get_perlcritic_errors($source, $uri->file)
-          if (defined $PLS::Server::State::CONFIG->{perlcritic}{enabled} and $PLS::Server::State::CONFIG->{perlcritic}{enabled});
+        # TODO: Remove the '1 or' when its clear what is going one with CONFIG.
+        push @futures, get_compilation_errors($source, $dir) if (1 or defined $PLS::Server::State::CONFIG->{syntax}{enabled} and $PLS::Server::State::CONFIG->{syntax}{enabled});
+        push @futures, get_perlcritic_errors($source, $uri->file) if (1 or defined $PLS::Server::State::CONFIG->{perlcritic}{enabled} and $PLS::Server::State::CONFIG->{perlcritic}{enabled});
     } ## end if (not $args{close})
 
     return Future->wait_all(@futures)->then(

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -63,9 +63,8 @@ sub new
 
     if (not $args{close})
     {
-        # TODO: Remove the '1 or' when its clear what is going one with CONFIG.
-        push @futures, get_compilation_errors($source, $dir) if (1 or defined $PLS::Server::State::CONFIG->{syntax}{enabled} and $PLS::Server::State::CONFIG->{syntax}{enabled});
-        push @futures, get_perlcritic_errors($source, $uri->file) if (1 or defined $PLS::Server::State::CONFIG->{perlcritic}{enabled} and $PLS::Server::State::CONFIG->{perlcritic}{enabled});
+        push @futures, get_compilation_errors($source, $dir) if (defined $PLS::Server::State::CONFIG->{syntax}{enabled} and $PLS::Server::State::CONFIG->{syntax}{enabled});
+        push @futures, get_perlcritic_errors($source, $uri->file) if (defined $PLS::Server::State::CONFIG->{perlcritic}{enabled} and $PLS::Server::State::CONFIG->{perlcritic}{enabled});
     } ## end if (not $args{close})
 
     return Future->wait_all(@futures)->then(

--- a/server/lib/PLS/Server/Request/Workspace/Configuration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/Configuration.pm
@@ -12,6 +12,8 @@ use PLS::Parser::Pod;
 use PLS::Server::State;
 use PLS::Server::Request::TextDocument::PublishDiagnostics;
 
+use JJ;
+
 =head1 NAME
 
 PLS::Server::Request::Workspace::Configuration
@@ -45,8 +47,43 @@ sub handle_response
 {
     my ($self, $response, $server) = @_;
 
+    JJ::jjlog("response", $response);
+
     return unless (Scalar::Util::reftype $response eq 'HASH' and ref $response->{result} eq 'ARRAY');
+
     my $config = $response->{result}[0];
+
+    # TODO: Remove this once we have figured out what is going on with BBEdit's WorkspaceConfigurations.
+    if (1) {
+        my $json = << 'EOF';
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "result": [
+    {
+      "inc": [],
+      "pls": "pls",
+      "syntax": {
+        "enabled": true,
+        "perl": ""
+      },
+      "perltidyrc": "~/.perltidyrc",
+      "perlcritic": {
+        "perlcriticrc": "~/.perlcriticrc",
+        "enabled": true
+      },
+      "cwd": "",
+      "sortImports": {
+        "args": []
+      }
+    }
+  ]
+}
+EOF
+
+        $config = JSON::PP->new->utf8->decode($json);
+    }
+
     return unless (ref $config eq 'HASH');
 
     # Replace $ROOT_PATH with actual workspace root in inc

--- a/server/lib/PLS/Server/Request/Workspace/Configuration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/Configuration.pm
@@ -38,7 +38,7 @@ sub new
         id     => undef,                       # assigned by the server
         method => 'workspace/configuration',
         params => {
-                   items => [{section => 'perl'}]
+                   items => [{section => 'perl', scopeUri => '*'}]
                   }
                  }, $class;
 } ## end sub new
@@ -52,37 +52,6 @@ sub handle_response
     return unless (Scalar::Util::reftype $response eq 'HASH' and ref $response->{result} eq 'ARRAY');
 
     my $config = $response->{result}[0];
-
-    # TODO: Remove this once we have figured out what is going on with BBEdit's WorkspaceConfigurations.
-    if (1) {
-        my $json = << 'EOF';
-{
-  "jsonrpc": "2.0",
-  "id": null,
-  "result": [
-    {
-      "inc": [],
-      "pls": "pls",
-      "syntax": {
-        "enabled": true,
-        "perl": ""
-      },
-      "perltidyrc": "~/.perltidyrc",
-      "perlcritic": {
-        "perlcriticrc": "~/.perlcriticrc",
-        "enabled": true
-      },
-      "cwd": "",
-      "sortImports": {
-        "args": []
-      }
-    }
-  ]
-}
-EOF
-
-        $config = JSON::PP->new->utf8->decode($json);
-    }
 
     return unless (ref $config eq 'HASH');
 

--- a/server/lib/PLS/Server/Response/Shutdown.pm
+++ b/server/lib/PLS/Server/Response/Shutdown.pm
@@ -1,0 +1,30 @@
+package PLS::Server::Response::Shutdown;
+
+use strict;
+use warnings;
+
+use parent q(PLS::Server::Response);
+
+=head1 NAME
+
+PLS::Server::Response::Shutdown
+
+=head1 DESCRIPTION
+
+This is a message from the server to the client acknowledging the shutdown.
+
+=cut
+
+sub new
+{
+    my ($class, $request) = @_;
+
+    my $self = bless {
+                      id     => $request->{id},
+                      result => undef
+                     }, $class;
+
+    return $self;
+} ## end sub new
+
+1;

--- a/server/t/00compile.t
+++ b/server/t/00compile.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 63;
+use Test::More tests => 66;
 
 use_ok('PLS');
 use_ok('PLS::Server');
@@ -39,6 +39,8 @@ use_ok('PLS::Server::Request::CancelRequest');
 use_ok('PLS::Server::Request::Factory');
 use_ok('PLS::Server::Request::Initialize');
 use_ok('PLS::Server::Request::Initialized');
+use_ok('PLS::Server::Request::Shutdown');
+use_ok('PLS::Server::Request::Exit');
 
 use_ok('PLS::Server::Response::Cancelled');
 use_ok('PLS::Server::Response::Completion');
@@ -51,6 +53,7 @@ use_ok('PLS::Server::Response::RangeFormatting');
 use_ok('PLS::Server::Response::Resolve');
 use_ok('PLS::Server::Response::ServerNotInitialized');
 use_ok('PLS::Server::Response::SignatureHelp');
+use_ok('PLS::Server::Response::Shutdown');
 
 use_ok('PLS::Server::Message');
 use_ok('PLS::Server::Request');

--- a/server/t/01server.t.bad
+++ b/server/t/01server.t.bad
@@ -98,6 +98,17 @@ sub initialize_server
     return $response;
 } ## end sub initialize_server
 
+sub shutdown_server
+{
+    my ($comm) = @_;
+
+    my $request  = slurp 'shutdown.json';
+    my $response = $comm->send_message_and_recv_response($request);
+    $request = slurp 'shutdown.json';
+    $comm->send_message($request);
+    return $response;
+} ## end sub shutdown_server
+
 sub complete_initialization
 {
     my ($comm) = @_;

--- a/server/t/packets/shutdown.json
+++ b/server/t/packets/shutdown.json
@@ -1,0 +1,6 @@
+{
+    "jsonrpc": "2.0",
+    "id": null,
+    "method": "shutdown",
+    "params": null
+}


### PR DESCRIPTION
Thank you for your good work on PLS.

I have been testing it with BBEdit which in its latest version supports language servers.

https://www.barebones.com/support/bbedit/lsp-notes.html

I came over 2 issues I had to get around and a feature request.

Issue 1. 
    
    PLS didn't support the 'shutdown' and 'exit' messages has required by the protocol specification.

    https://microsoft.github.io/language-server-protocol/specification#shutdown
    https://microsoft.github.io/language-server-protocol/specification#exit
    
    Has a consequence BBEdit was hanging when quitting or shutting down the server.
    
    Thanks to the clean architecture of PLS, it was easy to implement support for those message.
    
Issue 2. 
    
    I couldn't figure out how to make BBEdit correctly answer to the 'workspace/configuration' request.
    I temporarily short-circuited the response and hard-coded a default and reported the issue to the BBEdit support team.
    
Feature request
    
    To figure out what was going on in the conversation between BBEdit and PLS I implemented a primitive form of logging.
    It would be great if some more configurable form of logging was implemented in PLS.
    
With this provisional fixes, BBEdit now starts and stops the server correctly and appears to take advantage of the functionality provided by PLS.
