### PR TITLE
Regex fix for compilation errors with DATA

### DIFF
--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -152,7 +152,7 @@ sub get_compilation_errors
                     # Hide "BEGIN failed" and "Compilation failed" messages - these provide no useful info.
                     #next if $line =~ /^BEGIN failed/;
                     #next if $line =~ /^Compilation failed/;
-                    if (my ($error, $file, $line, $area) = $line =~ /^(.+) at (.+) line (\d+)(, .+)?/)
+                    if (my ($error, $file, $line, $area) = $line =~ /^(.+) at (.+?) line (\d+)(, .+)?/)
                     {
                         $error .= $area if (length $area);
                         $line = int $line;


### PR DESCRIPTION
This is a fix to the regular expression used for parsing compilation errors from perl -c. When a compilation error occurs after a imported module that has used the DATA section, the context of DATA is included. For example, when compile checking the following short file:

``` perl
use strict;
use PDL;
$foo=1;
```

gives the following error

`Global symbol "$foo" requires explicit package name (did you forget to declare "my $foo"?) at /tmp/testing.pl line 3, <DATA> line 197.`
PLS will run the regex on this, and then discard the error because the result of the 2nd capture group: `/tmp/testing.pl line 3, <DATA>` does not match the originally requested filename.

Looks like Perl::LanguageServer includes this capture group modifier as well: https://github.com/richterger/Perl-LanguageServer/blob/f4bd1f39630cb2c490c2f82d0e5e9bc8b410e8da/lib/Perl/LanguageServer/SyntaxChecker.pm#L263