### PR TITLE
Remove index file

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,118 +1,118 @@
 {
-    "name": "pls",
-    "displayName": "Perl Language Server (PLS)",
-    "description": "Perl Language Server",
-    "publisher": "FractalBoy",
-    "repository": "https://github.com/FractalBoy/perl-language-server/",
-    "license": "MIT",
-    "version": "0.0.15",
-    "engines": {
-        "vscode": "^1.50.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onLanguage:perl"
-    ],
-    "main": "./out/extension",
-    "icon": "pls.png",
-    "contributes": {
-        "configuration": {
-            "title": "Perl Language Server (PLS)",
-            "properties": {
-                "perl.inc": {
-                    "type": "array",
-                    "default": [],
-                    "description": "Paths to add to @INC."
-                },
-                "perl.pls": {
-                    "type": "string",
-                    "default": "pls",
-                    "description": "Path to the pls executable script"
-                },
-                "perl.plsargs": {
-                    "type": "array",
-                    "default": [],
-                    "description": "Arguments to pass to the pls command"
-                },
-                "perl.syntax.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enable syntax checking"
-                },
-                "perl.syntax.perl": {
-                    "type": "string",
-                    "default": "",
-                    "description": "Path to the perl binary to use for syntax checking"
-                },
-                "perl.syntax.perlargs": {
-                    "type": "array",
-                    "default": [],
-                    "description": "Additional arguments to pass to perl when syntax checking"
-                },
-                "perl.perltidyrc": {
-                    "type": "string",
-                    "default": "~/.perltidyrc",
-                    "description": "Path to .perltidyrc"
-                },
-                "perl.perlcritic.perlcriticrc": {
-                    "type": "string",
-                    "default": "~/.perlcriticrc",
-                    "description": "Path to .perlcriticrc"
-                },
-                "perl.perlcritic.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enable perlcritic"
-                },
-                "perl.cwd": {
-                    "type": "string",
-                    "default": ".",
-                    "description": "Current working directory to use"
-                }
-            }
+  "name": "pls",
+  "displayName": "Perl Language Server (PLS)",
+  "description": "Perl Language Server",
+  "publisher": "FractalBoy",
+  "repository": "https://github.com/FractalBoy/perl-language-server/",
+  "license": "MIT",
+  "version": "0.0.15",
+  "engines": {
+    "vscode": "^1.50.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:perl"
+  ],
+  "main": "./out/extension",
+  "icon": "pls.png",
+  "contributes": {
+    "configuration": {
+      "title": "Perl Language Server (PLS)",
+      "properties": {
+        "perl.inc": {
+          "type": "array",
+          "default": [],
+          "description": "Paths to add to @INC."
         },
-        "commands": {
-            "command": "perl.sortImports",
-            "title": "Sort Imports",
-            "category": "Perl Refactor"
+        "perl.pls": {
+          "type": "string",
+          "default": "pls",
+          "description": "Path to the pls executable script"
         },
-        "menus": {
-            "editor/context": [
-                {
-                    "command": "perl.sortImports",
-                    "title": "Refactor: Sort Imports",
-                    "group": "Refactor",
-                    "when": "editorLangId == perl"
-                }
-            ]
+        "perl.plsargs": {
+          "type": "array",
+          "default": [],
+          "description": "Arguments to pass to the pls command"
+        },
+        "perl.syntax.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable syntax checking"
+        },
+        "perl.syntax.perl": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the perl binary to use for syntax checking"
+        },
+        "perl.syntax.args": {
+          "type": "array",
+          "default": [],
+          "description": "Additional arguments to pass when syntax checking. This is useful if there is a BEGIN block in your code that changes behavior depending on the contents of @ARGV."
+        },
+        "perl.perltidyrc": {
+          "type": "string",
+          "default": "~/.perltidyrc",
+          "description": "Path to .perltidyrc"
+        },
+        "perl.perlcritic.perlcriticrc": {
+          "type": "string",
+          "default": "~/.perlcriticrc",
+          "description": "Path to .perlcriticrc"
+        },
+        "perl.perlcritic.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable perlcritic"
+        },
+        "perl.cwd": {
+          "type": "string",
+          "default": ".",
+          "description": "Current working directory to use"
         }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "webpack --mode production",
-        "webpack": "webpack --mode development",
-        "webpack-dev": "webpack --mode development --watch",
-        "test-compile": "tsc -p ./",
-        "test": "node ./out/test/runTest.js"
+    "commands": {
+      "command": "perl.sortImports",
+      "title": "Sort Imports",
+      "category": "Perl Refactor"
     },
-    "devDependencies": {
-        "@types/glob": "^7.1.3",
-        "@types/mocha": "^8.0.0",
-        "@types/node": "^12.11.7",
-        "@types/vscode": "^1.50.0",
-        "@typescript-eslint/eslint-plugin": "^4.1.1",
-        "@typescript-eslint/parser": "^4.1.1",
-        "eslint": "^7.9.0",
-        "glob": "^7.1.6",
-        "mocha": "^8.1.3",
-        "ts-loader": "^8.0.5",
-        "typescript": "^4.0.2",
-        "vscode-test": "^1.4.0",
-        "webpack": "^5.1.0",
-        "webpack-cli": "^4.0.0"
-    },
-    "dependencies": {
-        "vscode-languageclient": "7.0.0"
+    "menus": {
+      "editor/context": [
+        {
+          "command": "perl.sortImports",
+          "title": "Refactor: Sort Imports",
+          "group": "Refactor",
+          "when": "editorLangId == perl"
+        }
+      ]
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "webpack --mode production",
+    "webpack": "webpack --mode development",
+    "webpack-dev": "webpack --mode development --watch",
+    "test-compile": "tsc -p ./",
+    "test": "node ./out/test/runTest.js"
+  },
+  "devDependencies": {
+    "@types/glob": "^7.1.3",
+    "@types/mocha": "^8.0.0",
+    "@types/node": "^12.11.7",
+    "@types/vscode": "^1.50.0",
+    "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@typescript-eslint/parser": "^4.1.1",
+    "eslint": "^7.9.0",
+    "glob": "^7.1.6",
+    "mocha": "^8.1.3",
+    "ts-loader": "^8.0.5",
+    "typescript": "^4.0.2",
+    "vscode-test": "^1.4.0",
+    "webpack": "^5.1.0",
+    "webpack-cli": "^4.0.0"
+  },
+  "dependencies": {
+    "vscode-languageclient": "7.0.0"
+  }
 }

--- a/server/MANIFEST
+++ b/server/MANIFEST
@@ -46,6 +46,7 @@ lib/PLS/Server/Response/InvalidRequest.pm
 lib/PLS/Server/Message.pm
 lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
 lib/PLS/Server/Request/Workspace/DidChangeConfiguration.pm
+lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
 lib/PLS/Server/Request/Workspace/ExecuteCommand.pm
 lib/PLS/Server/Request/Workspace/ApplyEdit.pm
 lib/PLS/Server/Request/Workspace/Configuration.pm

--- a/server/lib/PLS/Parser/Document.pm
+++ b/server/lib/PLS/Parser/Document.pm
@@ -32,7 +32,6 @@ use PLS::Parser::Pod::Subroutine;
 use PLS::Parser::Pod::Variable;
 
 my %FILES;
-my $INDEX;
 
 =head1 NAME
 
@@ -82,43 +81,13 @@ sub new
                       uri  => $uri
                      }, $class;
 
-    $self->{index} = $self->get_index();
+    $self->{index} = PLS::Parser::Index->new();
     my $document = $self->_get_ppi_document(%args);
     return unless (ref $document eq 'PPI::Document');
     $self->{document} = $document;
 
     return $self;
 } ## end sub new
-
-=head2 set_index
-
-This sets the L<PLS::Parser::Index> object to be used by all L<PLS::Parser::Document>
-objects.
-
-=cut
-
-sub set_index
-{
-    my ($class, $index) = @_;
-
-    $INDEX = $index;
-}
-
-=head2 get_index
-
-This gets the L<PLS::Parser::Index> object to use.
-It will set it for other objects to use if it does not already exist.
-
-=cut
-
-sub get_index
-{
-    my ($class) = @_;
-
-    return                                                                   unless (length $PLS::Server::State::ROOT_PATH);
-    $INDEX = PLS::Parser::Index->new(root => $PLS::Server::State::ROOT_PATH) unless (ref $INDEX eq 'PLS::Parser::Index');
-    return $INDEX;
-} ## end sub get_index
 
 =head2 go_to_definition
 

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -11,6 +11,7 @@ use URI::file;
 use List::Util qw(any);
 use Path::Tiny;
 use PPR;
+use Storable;
 use Time::Piece;
 
 =head1 NAME
@@ -202,7 +203,7 @@ sub find_subroutine
         } @locations;
     } ## end if (scalar @uris)
 
-    return \@locations;
+    return Storable::dclone(\@locations);
 } ## end sub find_subroutine
 
 sub find_package
@@ -219,7 +220,7 @@ sub find_package
         return [];
     } ## end if (ref $found ne 'ARRAY'...)
 
-    return $found;
+    return Storable::dclone($found);
 } ## end sub find_package
 
 sub get_ignored_files

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -2,20 +2,21 @@ package PLS::Parser::Index;
 
 use strict;
 use warnings;
+
 use feature 'state';
 
 use File::Find;
-use File::stat;
 use File::Spec;
+use File::stat;
 use IO::Async::Function;
 use IO::Async::Loop;
-use URI::file;
 use List::Util qw(any);
-use Path::Tiny;
 use POSIX;
 use PPR;
+use Path::Tiny;
 use Storable;
 use Time::Piece;
+use URI::file;
 
 use PLS::Parser::Document;
 

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -152,7 +152,7 @@ sub cleanup_old_files
         {
             next unless (ref $index->{$type}{$ref} eq 'ARRAY');
             my $count_before = scalar @{$index->{$type}{$ref}};
-            @{$index->{$type}{$ref}} = grep { -e $_->{uri} } @{$index->{$type}{$ref}};
+            @{$index->{$type}{$ref}} = grep { -e URI->new($_->{uri})->file } @{$index->{$type}{$ref}};
             my $count_after = scalar @{$index->{$type}{$ref}};
             $refs_cleaned++ if ($count_after < $count_before);
         } ## end foreach my $ref (keys %{$index...})

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -485,6 +485,7 @@ sub get_subroutines
     state $sub_rx   = qr/((?&PerlSubroutineDeclaration))$PPR::GRAMMAR/;
     state $sig_rx   = qr/(?<label>(?<params>(?&PerlVariableDeclaration))(?&PerlOWS)=(?&PerlOWS)\@_)$PPR::GRAMMAR/;
     state $var_rx   = qr/((?&PerlVariable))$PPR::GRAMMAR/;
+    state $proto_rx = qr/\([^)]*+\)/;
     my %subroutines;
 
     my $uri = URI::file->new($file)->as_string();
@@ -514,8 +515,8 @@ sub get_subroutines
             }
         } ## end if ($block =~ /$sig_rx/...)
 
-        ($name) = $name =~ /(?:sub\s+)?(\S+)\s*[;{]/;
-        $name =~ s/\([^)]*+\)//;
+        ($name) = $name =~ /(?:sub\s+)?(\S+)\s*(?:$proto_rx)?\s*[;{]/;
+        $name =~ s/$proto_rx//;
         $name =~ s/^\s+|\s+$//g;
 
         push @{$subroutines{$name}},

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -38,14 +38,14 @@ sub new
                       cache => {},
                      }, $class;
 
-    $self->start_indexing_function();
-
     return $self;
 } ## end sub new
 
 sub start_indexing_function
 {
     my ($self) = @_;
+
+    return if (ref $self->{indexing_function} eq 'IO::Async::Function');
 
     $self->{indexing_function} = IO::Async::Function->new(
         code => sub {
@@ -97,6 +97,8 @@ sub start_indexing_function
 sub index_files
 {
     my ($self, @files) = @_;
+
+    $self->start_indexing_function();
 
     @files = @{$self->get_all_perl_files()} unless (scalar @files);
 

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -39,28 +39,60 @@ sub new
 
     my %args = @args;
     $self = bless {
-                   workspace_folders => $args{workspace_folders},
-                   cache             => {},
+                   workspace_folders   => $args{workspace_folders},
+                   subs                => {},
+                   packages            => {},
+                   files               => {},
+                   ignored_files       => {},
+                   ignore_files_mtimes => {}
                   }, $class;
 
     return $self;
 } ## end sub new
 
-sub start_indexing_function
+sub workspace_folders
+{
+    my ($self) = @_;
+
+    return $self->{workspace_folders};
+}
+
+sub subs
+{
+    my ($self) = @_;
+
+    return $self->{subs};
+}
+
+sub packages
+{
+    my ($self) = @_;
+
+    return $self->{packages};
+}
+
+sub files
+{
+    my ($self) = @_;
+
+    return $self->{files};
+}
+
+sub _start_indexing_function
 {
     my ($self) = @_;
 
     return if (ref $self->{indexing_function} eq 'IO::Async::Function');
 
-    $self->{indexing_function} = IO::Async::Function->new(code => \&_index_files);
+    $self->{indexing_function} = IO::Async::Function->new(code => \&_index_file);
 
     my $loop = IO::Async::Loop->new();
     $loop->add($self->{indexing_function});
 
     return;
-} ## end sub start_indexing_function
+} ## end sub _start_indexing_function
 
-sub _index_files
+sub _index_file
 {
     my ($file) = @_;
 
@@ -70,13 +102,13 @@ sub _index_files
     my $subroutines  = PLS::Parser::Index->get_subroutines($text, $file, $line_offsets);
 
     return $packages, $subroutines;
-} ## end sub _index_files
+} ## end sub _index_file
 
 sub index_files
 {
     my ($self, @files) = @_;
 
-    $self->start_indexing_function();
+    $self->_start_indexing_function();
 
     @files = @{$self->get_all_perl_files()} unless (scalar @files);
 
@@ -91,19 +123,19 @@ sub index_files
 
                 foreach my $type (qw(subs packages))
                 {
-                    $self->cleanup_index($type, $file);
+                    $self->_cleanup_index($type, $file);
                 }
 
                 foreach my $ref (keys %{$packages})
                 {
-                    push @{$self->{cache}{packages}{$ref}}, @{$packages->{$ref}};
-                    push @{$self->{cache}{files}{$file}{packages}}, $ref;
+                    push @{$self->packages->{$ref}},         @{$packages->{$ref}};
+                    push @{$self->files->{$file}{packages}}, $ref;
                 }
 
                 foreach my $ref (keys %{$subs})
                 {
-                    push @{$self->{cache}{subs}{$ref}}, @{$subs->{$ref}};
-                    push @{$self->{cache}{files}{$file}{subs}}, $ref;
+                    push @{$self->subs->{$ref}},         @{$subs->{$ref}};
+                    push @{$self->files->{$file}{subs}}, $ref;
                 }
 
                 return;
@@ -118,15 +150,15 @@ sub deindex_workspace
 {
     my ($self, $path) = @_;
 
-    @{$self->{workspace_folders}} = grep { $_ ne $path } @{$self->{workspace_folders}};
+    @{$self->workspace_folders} = grep { $_ ne $path } @{$self->workspace_folders};
 
-    foreach my $file (keys %{$self->{cache}{files}})
+    foreach my $file (keys %{$self->files})
     {
         next unless path($path)->subsumes($file);
 
         foreach my $type (qw(subs packages))
         {
-            $self->cleanup_index($type, $file);
+            $self->_cleanup_index($type, $file);
         }
     } ## end foreach my $file (keys %{$self...})
 
@@ -137,7 +169,7 @@ sub index_workspace
 {
     my ($self, $path) = @_;
 
-    push @{$self->{workspace_folders}}, $path;
+    push @{$self->workspace_folders}, $path;
 
     my @workspace_files = @{$self->get_all_perl_files($path)};
     $self->index_files(@workspace_files);
@@ -145,79 +177,43 @@ sub index_workspace
     return;
 } ## end sub index_workspace
 
-sub cleanup_index
+sub _cleanup_index
 {
     my ($self, $type, $file) = @_;
 
-    my $index = $self->{cache};
-
-    if (ref $index->{files}{$file}{$type} eq 'ARRAY')
+    if (ref $self->files->{$file}{$type} eq 'ARRAY')
     {
-        foreach my $ref (@{$index->{files}{$file}{$type}})
+        foreach my $ref (@{$self->files->{$file}{$type}})
         {
-            @{$index->{$type}{$ref}} = grep { $_->{uri} ne URI::file->new($file)->as_string() } @{$index->{$type}{$ref}};
-            delete $index->{$type}{$ref} unless (scalar @{$index->{$type}{$ref}});
+            @{$self->$type->{$ref}} = grep { $_->{uri} ne URI::file->new($file)->as_string() } @{$self->$type->{$ref}};
+            delete $self->$type->{$ref} unless (scalar @{$self->$type->{$ref}});
         }
 
-        @{$index->{files}{$file}{$type}} = ();
-    } ## end if (ref $index->{files...})
+        @{$self->files->{$file}{$type}} = ();
+    } ## end if (ref $self->files->...)
     else
     {
-        $index->{files}{$file}{$type} = [];
+        $self->files->{$file}{$type} = [];
     }
 
     return;
-} ## end sub cleanup_index
+} ## end sub _cleanup_index
 
 sub cleanup_old_files
 {
     my ($self) = @_;
 
-    my $index = $self->{cache};
-
-    if (ref $index->{files} eq 'HASH')
+    foreach my $file (keys %{$self->files})
     {
-        foreach my $file (keys %{$index->{files}})
+        next if (-e $file);
+
+        foreach my $type (qw(subs packages))
         {
-            next if -f $file;
+            $self->_cleanup_index($type, $file);
+        }
 
-            if (ref $index->{subs} eq 'HASH')
-            {
-                foreach my $sub (@{$index->{files}{$file}{subs}})
-                {
-                    next unless (ref $index->{subs}{$sub} eq 'ARRAY');
-                    @{$index->{subs}{$sub}} = grep { $_->{uri} eq URI::file->new($file)->as_string() } @{$index->{subs}{$sub}};
-                    delete $index->{subs}{$sub} unless (scalar @{$index->{subs}{$sub}});
-                } ## end foreach my $sub (@{$index->...})
-            } ## end if (ref $index->{subs}...)
-
-            if (ref $index->{packages} eq 'HASH')
-            {
-                foreach my $package (@{$index->{files}{$file}{packages}})
-                {
-                    next unless (ref $index->{packages}{$package} eq 'ARRAY');
-                    @{$index->{packages}{$package}} = grep { $_->{uri} eq URI::file->new($file)->as_string() } @{$index->{packages}{$package}};
-                    delete $index->{packages}{$package} unless (scalar @{$index->{packages}{$package}});
-                } ## end foreach my $package (@{$index...})
-            } ## end if (ref $index->{packages...})
-
-            delete $index->{files}{$file};
-        } ## end foreach my $file (keys %{$index...})
-    } ## end if (ref $index->{files...})
-
-    foreach my $type (keys %{$index})
-    {
-        my $refs_cleaned = 0;
-
-        foreach my $ref (keys %{$index->{$type}})
-        {
-            next unless (ref $index->{$type}{$ref} eq 'ARRAY');
-            my $count_before = scalar @{$index->{$type}{$ref}};
-            @{$index->{$type}{$ref}} = grep { -e URI->new($_->{uri})->file } @{$index->{$type}{$ref}};
-            my $count_after = scalar @{$index->{$type}{$ref}};
-            $refs_cleaned++ if ($count_after < $count_before);
-        } ## end foreach my $ref (keys %{$index...})
-    } ## end foreach my $type (keys %{$index...})
+        delete $self->files->{$file};
+    } ## end foreach my $file (keys %{$self...})
 
     return;
 } ## end sub cleanup_old_files
@@ -226,8 +222,7 @@ sub find_package_subroutine
 {
     my ($self, $package, $subroutine) = @_;
 
-    my $index     = $self->{cache};
-    my $locations = $index->{packages}{$package};
+    my $locations = $self->packages->{$package};
 
     if (ref $locations ne 'ARRAY')
     {
@@ -248,29 +243,20 @@ sub find_subroutine
 {
     my ($self, $subroutine, @uris) = @_;
 
-    my $index = $self->{cache};
-    my $found = $index->{subs}{$subroutine};
+    my $found = $self->subs->{$subroutine};
     return [] unless (ref $found eq 'ARRAY');
 
-    my @locations = @$found;
+    my %uris = map { $_ => 1 } @uris;
+    @{$found} = grep { $uris{$_} } @{$found} if (scalar @uris);
 
-    if (scalar @uris)
-    {
-        @locations = grep {
-            my $location = $_;
-            scalar grep { $location->{uri} eq $_ } @uris;
-        } @locations;
-    } ## end if (scalar @uris)
-
-    return Storable::dclone(\@locations);
+    return Storable::dclone($found);
 } ## end sub find_subroutine
 
 sub find_package
 {
     my ($self, $package) = @_;
 
-    my $index = $self->{cache};
-    my $found = $index->{packages}{$package};
+    my $found = $self->packages->{$package};
 
     if (ref $found ne 'ARRAY')
     {
@@ -288,7 +274,7 @@ sub get_ignored_files
 
     my @ignored_files;
 
-    foreach my $workspace_folder (@{$self->{workspace_folders}})
+    foreach my $workspace_folder (@{$self->workspace_folders})
     {
         my $plsignore = File::Spec->catfile($workspace_folder, '.plsignore');
         next if (not -f $plsignore or not -r $plsignore);
@@ -317,16 +303,16 @@ sub get_all_subroutines
 {
     my ($self) = @_;
 
-    return [] if (ref $self->{cache}{subs} ne 'HASH');
-    return [keys %{$self->{cache}{subs}}];
+    return [] if (ref $self->subs ne 'HASH');
+    return [keys %{$self->subs}];
 } ## end sub get_all_subroutines
 
 sub get_all_packages
 {
     my ($self) = @_;
 
-    return [] if (ref $self->{cache}{packages} ne 'HASH');
-    return [keys %{$self->{cache}{packages}}];
+    return [] if (ref $self->packages ne 'HASH');
+    return [keys %{$self->packages}];
 } ## end sub get_all_packages
 
 sub is_ignored
@@ -334,7 +320,7 @@ sub is_ignored
     my ($self, $file) = @_;
 
     my @ignore_files = @{$self->get_ignored_files()};
-    return if not scalar @ignore_files;
+    return unless (scalar @ignore_files);
 
     my $real_path = path($file)->realpath;
 
@@ -348,8 +334,8 @@ sub get_all_perl_files
 {
     my ($self, @folders) = @_;
 
-    @folders = @{$self->{workspace_folders}} unless (scalar @folders);
-    return []                                unless (scalar @folders);
+    @folders = @{$self->workspace_folders} unless (scalar @folders);
+    return []                              unless (scalar @folders);
 
     my @perl_files;
 
@@ -370,7 +356,7 @@ sub get_all_perl_files
          }
         },
         @folders
-                    );
+    );
 
     return \@perl_files;
 } ## end sub get_all_perl_files

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -232,12 +232,14 @@ sub find_package_subroutine
         return [];
     } ## end if (ref $locations ne ...)
 
+    my @subroutines;
+
     foreach my $file (@{$locations})
     {
-        return $self->find_subroutine($subroutine, $file->{uri});
+        push @subroutines, @{$self->find_subroutine($subroutine, $file->{uri})};
     }
 
-    return;
+    return \@subroutines;
 } ## end sub find_package_subroutine
 
 sub find_subroutine

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -39,7 +39,6 @@ sub new
                      }, $class;
 
     $self->start_indexing_function();
-    $self->index_files();
 
     return $self;
 } ## end sub new

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -397,14 +397,16 @@ sub get_packages
         push @{$packages{$name}},
           {
             uri   => URI::file->new($file)->as_string(),
-            start => {
-                      line      => $start_line,
-                      character => $start
-                     },
-            end => {
-                    line      => $end_line,
-                    character => $end
-                   }
+            range => {
+                      start => {
+                                line      => $start_line,
+                                character => $start
+                               },
+                      end => {
+                              line      => $end_line,
+                              character => $end
+                             }
+                     }
           };
     } ## end while ($$text =~ /$rx/g)
 
@@ -457,14 +459,16 @@ sub get_subroutines
         push @{$subroutines{$name}},
           {
             uri   => URI::file->new($file)->as_string(),
-            start => {
-                      line      => $start_line,
-                      character => $start
+            range => {
+                      start => {
+                                line      => $start_line,
+                                character => $start
+                               },
+                      end => {
+                              line      => $end_line,
+                              character => $end
+                             }
                      },
-            end => {
-                    line      => $end_line,
-                    character => $end
-                   },
             signature => {label => $signature, parameters => \@parameters}
           };
     } ## end while ($$text =~ /$sub_rx/g...)

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -4,20 +4,14 @@ use strict;
 use warnings;
 use feature 'state';
 
-use Fcntl qw(:flock);
 use File::Find;
-use File::Path;
 use File::stat;
 use File::Spec;
-use FindBin;
-use IO::Async::Loop;
-use IO::Async::Function;
-use List::Util qw(all any);
+use URI::file;
+use List::Util qw(any);
 use Path::Tiny;
+use PPR;
 use Time::Piece;
-use Storable;
-
-use constant {INDEX_LOCATION => File::Spec->catfile('.pls_cache', 'index')};
 
 =head1 NAME
 
@@ -37,210 +31,68 @@ sub new
     my %args = @args;
 
     my $self = bless {
-                      root       => $args{root},
-                      location   => File::Spec->catfile($args{root}, INDEX_LOCATION),
-                      cache      => {},
-                      last_mtime => 0,
+                      root  => $args{root},
+                      cache => {},
                      }, $class;
 
-    my (undef, $parent_dir) = File::Spec->splitpath($self->{location});
-    File::Path::make_path($parent_dir);
-
-    $self->start_indexing_function();
-    $self->start_cleanup_function();
+    $self->index_files();
 
     return $self;
 } ## end sub new
-
-sub start_indexing_function
-{
-    my ($self) = @_;
-
-    my $loop = IO::Async::Loop->new();
-
-    $self->{indexing_function} = IO::Async::Function->new(
-        min_workers => 0,
-        max_workers => 1,
-        code        => sub {
-            my ($self, @files) = @_;
-
-            # Lock the index file for this critical section of code
-            open my $fh, '>>', $self->{location} or die $!;
-            flock $fh, LOCK_EX;
-
-            my $index = $self->index(1);    # 1 indicates that we should not try to lock again
-
-            unless (scalar @files)
-            {
-                @files = @{$self->get_all_perl_files()};
-                $self->_cleanup_old_files($index);
-                @files = grep { not exists $index->{files}{$_}{last_mtime} or not length $index->{files}{$_}{last_mtime} and $index->{files}{$_}{last_mtime} < stat($_)->mtime } @files;
-            } ## end unless (scalar @files)
-
-            my $total   = scalar @files;
-            my $current = 0;
-
-            foreach my $file (@files)
-            {
-                $current++;
-
-                open my $fh, '<', $file or next;
-                my $text     = do { local $/; <$fh> };
-                my $document = PLS::Parser::Document->new(path => $file, text => \$text, no_cache => 1);
-                next unless (ref $document eq 'PLS::Parser::Document');
-
-                my $log_message = "Indexing $file";
-                $log_message .= " ($current/$total)" if (scalar @files > 1);
-                $log_message .= '...';
-
-                $self->log($log_message);
-
-                $self->update_subroutines($index, $document);
-                $self->update_packages($index, $document);
-            } ## end foreach my $file (@files)
-
-            $self->save($index);
-
-            flock $fh, LOCK_UN;
-
-            return [@{$self}{qw(cache last_mtime)}];
-        },
-        idle_timeout     => 30,
-        max_worker_calls => 20
-    );
-
-    $loop->add($self->{indexing_function});
-
-    return;
-} ## end sub start_indexing_function
-
-sub start_cleanup_function
-{
-    my ($self) = @_;
-
-    my $loop = IO::Async::Loop->new();
-
-    $self->{cleanup_function} = IO::Async::Function->new(
-        min_workers => 0,
-        max_workers => 1,
-        code        => sub {
-            my ($self) = @_;
-
-            # Lock the index file for this critical section of code
-            open my $fh, '>>', $self->{location} or die $!;
-            flock $fh, LOCK_EX;
-
-            my $index = $self->index(1);    # 1 indicates that we should not try to lock again
-            $self->_cleanup_old_files($index);
-            $self->save($index);
-
-            flock $fh, LOCK_UN;
-
-            return [@{$self}{qw(cache last_mtime)}];
-        },
-        idle_timeout     => 30,
-        max_worker_calls => 20
-    );
-
-    $loop->add($self->{cleanup_function});
-
-    return;
-} ## end sub start_cleanup_function
 
 sub index_files
 {
     my ($self, @files) = @_;
 
-    my $class     = ref $self;
-    my $self_copy = bless {%{$self}{qw(root location cache last_mtime)}}, $class;
+    @files = @{$self->get_all_perl_files()} unless (scalar @files);
 
-    $self->{indexing_function}->call(
-        args      => [$self_copy, @files],
-        on_result => sub {
-            my ($result, $data) = @_;
+    my $current = 0;
+    my $total   = scalar @files;
 
-            return if ($result ne 'return');
+    foreach my $file (@files)
+    {
+        $current++;
+        open my $fh, '<', $file or next;
 
-            @{$self}{qw(cache last_mtime)} = @{$data};
+        my $log_message = "Indexing $file";
+        $log_message .= " ($current/$total)" if ($total > 1);
+        $log_message .= '...';
+
+        $self->log($log_message);
+
+        my $text         = do { local $/; <$fh> };
+        my $line_offsets = $self->get_line_offsets(\$text);
+        my $packages     = $self->get_packages(\$text, $file, $line_offsets);
+        my $subroutines  = $self->get_subroutines(\$text, $file, $line_offsets);
+
+        foreach my $name (keys %{$packages})
+        {
+            push @{$self->{cache}{packages}{$name}},        @{$packages->{$name}};
+            push @{$self->{cache}{files}{$file}{packages}}, $name;
         }
-    );
+
+        foreach my $name (keys %{$subroutines})
+        {
+            push @{$self->{cache}{subs}{$name}},        @{$subroutines->{$name}};
+            push @{$self->{cache}{files}{$file}{subs}}, $name;
+        }
+
+    } ## end foreach my $file (@files)
 
     return;
 } ## end sub index_files
 
-sub save
-{
-    my ($self, $index) = @_;
-
-    my (undef, $parent_dir) = File::Spec->splitpath($self->{location});
-    File::Path::make_path($parent_dir);
-
-    Storable::nstore($index, $self->{location});
-
-    $self->{cache}      = $index;
-    $self->{last_mtime} = (stat $self->{location})->mtime;
-
-    return;
-} ## end sub save
-
-sub index
-{
-    my ($self, $no_lock) = @_;
-
-    return {} unless -f $self->{location};
-
-    my $mtime = (stat $self->{location})->mtime;
-    return $self->{cache} if ($mtime <= $self->{last_mtime});
-
-    $self->{last_mtime} = $mtime;
-
-    open my $fh, '<', $self->{location} or die $!;
-
-    unless ($no_lock)
-    {
-        my $locked = flock $fh, LOCK_SH | LOCK_NB;
-        return unless $locked;
-    }
-
-    $self->{cache} = eval { Storable::fd_retrieve($fh) };
-    flock $fh, LOCK_UN unless $no_lock;
-
-    return $self->{cache};
-} ## end sub index
-
-sub update_subroutines
-{
-    my ($self, $index, $document) = @_;
-
-    my $subroutines = $document->get_subroutines();
-    my $constants   = $document->get_constants();
-
-    $self->cleanup_index($index, 'subs', $document->{path});
-    $self->update_index($index, 'subs', $document->{path}, @$subroutines, @$constants);
-    return;
-} ## end sub update_subroutines
-
-sub update_packages
-{
-    my ($self, $index, $document) = @_;
-
-    my $packages = $document->get_packages();
-
-    $self->cleanup_index($index, 'packages', $document->{path});
-    return unless (ref $packages eq 'ARRAY');
-    $self->update_index($index, 'packages', $document->{path}, @$packages);
-    return;
-} ## end sub update_packages
-
 sub cleanup_index
 {
-    my ($self, $index, $type, $file) = @_;
+    my ($self, $type, $file) = @_;
+
+    my $index = $self->{cache};
 
     if (ref $index->{files}{$file}{$type} eq 'ARRAY')
     {
         foreach my $ref (@{$index->{files}{$file}{$type}})
         {
-            @{$index->{$type}{$ref}} = grep { $_->{file} ne $file } @{$index->{$type}{$ref}};
+            @{$index->{$type}{$ref}} = grep { $_->{uri} ne $file } @{$index->{$type}{$ref}};
             delete $index->{$type}{$ref} unless (scalar @{$index->{$type}{$ref}});
         }
 
@@ -254,58 +106,11 @@ sub cleanup_index
     return;
 } ## end sub cleanup_index
 
-sub update_index
-{
-    my ($self, $index, $type, $file, @references) = @_;
-
-    my $stat = stat $file;
-    return unless (ref $stat eq 'File::stat');
-
-    foreach my $reference (@references)
-    {
-        my $info = $reference->location_info();
-
-        if (ref $index->{$type}{$reference->name} eq 'ARRAY')
-        {
-            push @{$index->{$type}{$reference->name}}, $info;
-        }
-        else
-        {
-            $index->{$type}{$reference->name} = [$info];
-        }
-
-        push @{$index->{files}{$file}{$type}}, $reference->name;
-    } ## end foreach my $reference (@references...)
-
-    $index->{files}{$file}{last_mtime} = $stat->mtime;
-
-    return;
-} ## end sub update_index
-
 sub cleanup_old_files
 {
     my ($self) = @_;
 
-    my $class     = ref $self;
-    my $self_copy = bless {%{$self}{qw(root location cache last_mtime)}}, $class;
-
-    $self->{cleanup_function}->call(
-        args      => [$self_copy],
-        on_result => sub {
-            my ($result, $data) = @_;
-
-            return if ($result ne 'return');
-
-            @{$self}{qw(cache last_mtime)} = @{$data};
-        }
-    );
-
-    return;
-} ## end sub cleanup_old_files
-
-sub _cleanup_old_files
-{
-    my ($self, $index) = @_;
+    my $index = $self->{cache};
 
     if (ref $index->{files} eq 'HASH')
     {
@@ -319,7 +124,7 @@ sub _cleanup_old_files
                 foreach my $sub (@{$index->{files}{$file}{subs}})
                 {
                     next unless (ref $index->{subs}{$sub} eq 'ARRAY');
-                    @{$index->{subs}{$sub}} = grep { $_->{file} eq $file } @{$index->{subs}{$sub}};
+                    @{$index->{subs}{$sub}} = grep { $_->{uri} eq $file } @{$index->{subs}{$sub}};
                     delete $index->{subs}{$sub} unless (scalar @{$index->{subs}{$sub}});
                 } ## end foreach my $sub (@{$index->...})
             } ## end if (ref $index->{subs}...)
@@ -329,7 +134,7 @@ sub _cleanup_old_files
                 foreach my $package (@{$index->{files}{$file}{packages}})
                 {
                     next unless (ref $index->{packages}{$package} eq 'ARRAY');
-                    @{$index->{packages}{$package}} = grep { $_->{file} eq $file } @{$index->{packages}{$package}};
+                    @{$index->{packages}{$package}} = grep { $_->{uri} eq $file } @{$index->{packages}{$package}};
                     delete $index->{packages}{$package} unless (scalar @{$index->{packages}{$package}});
                 } ## end foreach my $package (@{$index...})
             } ## end if (ref $index->{packages...})
@@ -346,7 +151,7 @@ sub _cleanup_old_files
         {
             next unless (ref $index->{$type}{$ref} eq 'ARRAY');
             my $count_before = scalar @{$index->{$type}{$ref}};
-            @{$index->{$type}{$ref}} = grep { -e $_->{file} } @{$index->{$type}{$ref}};
+            @{$index->{$type}{$ref}} = grep { -e $_->{uri} } @{$index->{$type}{$ref}};
             my $count_after = scalar @{$index->{$type}{$ref}};
             $refs_cleaned++ if ($count_after < $count_before);
         } ## end foreach my $ref (keys %{$index...})
@@ -355,14 +160,13 @@ sub _cleanup_old_files
     } ## end foreach my $type (keys %{$index...})
 
     return;
-} ## end sub _cleanup_old_files
+} ## end sub cleanup_old_files
 
 sub find_package_subroutine
 {
     my ($self, $package, $subroutine) = @_;
 
-    my $index = $self->index();
-    return [] if (ref $index ne 'HASH');
+    my $index     = $self->{cache};
     my $locations = $index->{packages}{$package};
 
     if (ref $locations ne 'ARRAY')
@@ -372,9 +176,9 @@ sub find_package_subroutine
         return [];
     } ## end if (ref $locations ne ...)
 
-    foreach my $file (@$locations)
+    foreach my $file (@{$locations})
     {
-        return $self->find_subroutine($subroutine, $file->{file});
+        return $self->find_subroutine($subroutine, $file->{uri});
     }
 
     return;
@@ -382,49 +186,30 @@ sub find_package_subroutine
 
 sub find_subroutine
 {
-    my ($self, $subroutine, @files) = @_;
+    my ($self, $subroutine, @uris) = @_;
 
-    my $index = $self->index;
-    return [] if (ref $index ne 'HASH');
+    my $index = $self->{cache};
     my $found = $index->{subs}{$subroutine};
     return [] unless (ref $found eq 'ARRAY');
 
     my @locations = @$found;
 
-    if (scalar @files)
+    if (scalar @uris)
     {
         @locations = grep {
             my $location = $_;
-            scalar grep { $location->{file} eq $_ } @files;
+            scalar grep { $location->{uri} eq $_ } @uris;
         } @locations;
-    } ## end if (scalar @files)
+    } ## end if (scalar @uris)
 
-    return [
-        map {
-            {
-             uri   => URI::file->new($_->{file})->as_string,
-             range => {
-                       start => {
-                                 line      => $_->{location}{line_number},
-                                 character => $_->{location}{column_number}
-                                },
-                       end => {
-                               line      => $_->{location}{line_number},
-                               character => $_->{location}{column_number} + (length $subroutine) + ($_->{constant} ? 0 : (length 'sub '))
-                              }
-                      },
-             signature => $_->{signature}
-            }
-          } @locations
-    ];
+    return \@locations;
 } ## end sub find_subroutine
 
 sub find_package
 {
-    my ($self, $package, @files) = @_;
+    my ($self, $package) = @_;
 
-    my $index = $self->index;
-    return [] if (ref $index ne 'HASH');
+    my $index = $self->{cache};
     my $found = $index->{packages}{$package};
 
     if (ref $found ne 'ARRAY')
@@ -434,33 +219,7 @@ sub find_package
         return [];
     } ## end if (ref $found ne 'ARRAY'...)
 
-    my @locations = @$found;
-
-    if (scalar @files)
-    {
-        @locations = grep {
-            my $location = $_;
-            grep { $location->{file} eq $_ } @files
-        } @locations;
-    } ## end if (scalar @files)
-
-    return [
-        map {
-            {
-             uri   => URI::file->new($_->{file})->as_string,
-             range => {
-                       start => {
-                                 line      => $_->{location}{line_number},
-                                 character => $_->{location}{column_number}
-                                },
-                       end => {
-                               line      => $_->{location}{line_number},
-                               character => $_->{location}{column_number} + length("package $package;")
-                              }
-                      }
-            }
-          } @locations
-    ];
+    return $found;
 } ## end sub find_package
 
 sub get_ignored_files
@@ -579,5 +338,137 @@ sub log
 
     return;
 } ## end sub log
+
+sub get_line_offsets
+{
+    my ($class, $text) = @_;
+
+    my @line_offsets = (0);
+
+    while ($$text =~ /\r?\n/g)
+    {
+        push @line_offsets, pos($$text);
+    }
+
+    return \@line_offsets;
+} ## end sub get_line_offsets
+
+sub get_line_by_offset
+{
+    my ($class, $line_offsets, $offset) = @_;
+
+    for (my $i = 0 ; $i <= $#{$line_offsets} ; $i++)
+    {
+        my $current_offset = $line_offsets->[$i];
+        my $next_offset    = $i + 1 <= $#{$line_offsets} ? $line_offsets->[$i + 1] : undef;
+
+        if ($current_offset <= $offset and (not defined $next_offset or $next_offset > $offset))
+        {
+            return $i;
+        }
+    } ## end for (my $i = 0 ; $i <= ...)
+
+    return $#{$line_offsets};
+} ## end sub get_line_by_offset
+
+sub get_packages
+{
+    my ($class, $text, $file, $line_offsets) = @_;
+
+    state $rx = qr/((?&PerlPackageDeclaration))$PPR::GRAMMAR/x;
+    my %packages;
+
+    while ($$text =~ /$rx/g)
+    {
+        my $name = $1;
+
+        my $end        = pos($$text);
+        my $start      = $end - length $name;
+        my $start_line = $class->get_line_by_offset($line_offsets, $start);
+        $start -= $line_offsets->[$start_line];
+        my $end_line = $class->get_line_by_offset($line_offsets, $end);
+        $end -= $line_offsets->[$end_line];
+
+        $name =~ s/package//;
+        $name =~ s/^\s+|\s+$//g;
+        $name =~ s/;$//g;
+
+        push @{$packages{$name}},
+          {
+            uri   => URI::file->new($file)->as_string(),
+            start => {
+                      line      => $start_line,
+                      character => $start
+                     },
+            end => {
+                    line      => $end_line,
+                    character => $end
+                   }
+          };
+    } ## end while ($$text =~ /$rx/g)
+
+    return \%packages;
+} ## end sub get_packages
+
+sub get_subroutines
+{
+    my ($class, $text, $file, $line_offsets) = @_;
+
+    state $sub_rx   = qr/((?&PerlSubroutineDeclaration))$PPR::GRAMMAR/;
+    state $block_rx = qr/((?&PerlOWS)(?&PerlBlock))$PPR::GRAMMAR/;
+    state $sig_rx   = qr/(?<label>(?<params>(?&PerlVariableDeclaration))(?&PerlOWS)=(?&PerlOWS)\@_)$PPR::GRAMMAR/;
+    state $var_rx   = qr/((?&PerlVariable))$PPR::GRAMMAR/;
+    my %subroutines;
+
+    while ($$text =~ /$sub_rx/g)
+    {
+        my $name = $1;
+        my $end  = pos($$text);
+
+        my $start = $end - length $name;
+
+        my $start_line = $class->get_line_by_offset($line_offsets, $start);
+        $start -= $line_offsets->[$start_line];
+        my $end_line = $class->get_line_by_offset($line_offsets, $end);
+        $end -= $line_offsets->[$end_line];
+
+        my $signature;
+        my @parameters;
+
+        if ($name =~ s/$block_rx//)
+        {
+            my $block = $1;
+
+            if ($block =~ /$sig_rx/)
+            {
+                $signature = $+{label};
+                my $parameters = $+{params};
+                while ($parameters =~ /$var_rx/g)
+                {
+                    push @parameters, {label => $1};
+                }
+            } ## end if ($block =~ /$sig_rx/...)
+        } ## end if ($name =~ s/$block_rx//...)
+
+        $name =~ s/my|our|state|sub//g;
+        $name =~ s/^\s+|\s+$//g;
+
+        push @{$subroutines{$name}},
+          {
+            uri   => URI::file->new($file)->as_string(),
+            start => {
+                      line      => $start_line,
+                      character => $start
+                     },
+            end => {
+                    line      => $end_line,
+                    character => $end
+                   },
+            signature => {label => $signature, parameters => \@parameters}
+          };
+    } ## end while ($$text =~ /$sub_rx/g...)
+
+    return \%subroutines;
+} ## end sub get_subroutines
 
 1;

--- a/server/lib/PLS/Parser/Index.pm
+++ b/server/lib/PLS/Parser/Index.pm
@@ -99,10 +99,8 @@ sub index_files
 {
     my ($self, @files) = @_;
 
-    my $class     = ref $self;
-    my $self_copy = bless {%{$self}{qw(root cache)}}, $class;
-
     @files = @{$self->get_all_perl_files()} unless (scalar @files);
+
     my $chunk_size  = POSIX::ceil(scalar @files / $self->{indexing_function}{max_workers});
     my $job_id      = 1;
     my $total_files = scalar @files;

--- a/server/lib/PLS/Parser/PackageSymbols.pm
+++ b/server/lib/PLS/Parser/PackageSymbols.pm
@@ -3,7 +3,7 @@ package PLS::Parser::PackageSymbols;
 use strict;
 use warnings;
 
-use Fcntl ();
+use Fcntl    ();
 use Storable ();
 
 use PLS::Parser::Index;
@@ -35,7 +35,7 @@ sub get_package_functions
     # which folder the code will ultimately be in, and it doesn't really matter
     # for anyone except me.
     my $index = PLS::Parser::Index->new();
-    my $cwd = $PLS::Server::State::CONFIG->{cwd};
+    my $cwd   = $PLS::Server::State::CONFIG->{cwd};
     $cwd =~ s/\$ROOT_PATH/$index->{workspace_folders}[0]/;
 
     my $pid = fork;
@@ -55,12 +55,12 @@ sub get_package_functions
             kill 'KILL', $pid;
             waitpid $pid, 0;
             return;
-        }
+        } ## end if ($timeout)
 
         waitpid $pid, 0;
         return if (ref $result ne 'HASH' or not $result->{ok});
         return $result->{functions};
-    }
+    } ## end if ($pid)
     else
     {
         close $read_fh;
@@ -68,12 +68,12 @@ sub get_package_functions
         my $flags = fcntl $write_fh, Fcntl::F_GETFD, 0;
         fcntl $write_fh, Fcntl::F_SETFD, $flags & ~Fcntl::FD_CLOEXEC;
 
-        my @inc = map { "-I$_" } @{$config->{inc} // []};
+        my @inc  = map { "-I$_" } @{$config->{inc} // []};
         my $perl = PLS::Parser::Pod->get_perl_exe();
 
         chdir $cwd;
         exec $perl, @inc, '-e', $script, fileno($write_fh), $package;
-    }
+    } ## end else [ if ($pid) ]
 } ## end sub get_package_functions
 
 1;

--- a/server/lib/PLS/Parser/PackageSymbols.pm
+++ b/server/lib/PLS/Parser/PackageSymbols.pm
@@ -34,9 +34,9 @@ sub get_package_functions
     # Just use the first workspace folder as ROOT_PATH - we don't know
     # which folder the code will ultimately be in, and it doesn't really matter
     # for anyone except me.
-    my $index = PLS::Parser::Index->new();
-    my $cwd   = $PLS::Server::State::CONFIG->{cwd};
-    $cwd =~ s/\$ROOT_PATH/$index->{workspace_folders}[0]/;
+    my ($workspace_folder) = @{PLS::Parser::Index->new->workspace_folders};
+    my $cwd = $PLS::Server::State::CONFIG->{cwd};
+    $cwd =~ s/\$ROOT_PATH/$workspace_folder/;
 
     my $pid = fork;
 

--- a/server/lib/PLS/Parser/Pod.pm
+++ b/server/lib/PLS/Parser/Pod.pm
@@ -24,7 +24,7 @@ for sending to the Language Server Protocol.
 
 =cut
 
-my $PERL_EXE = $^X;
+my $PERL_EXE  = $^X;
 my $PERL_ARGS = [];
 
 sub new

--- a/server/lib/PLS/Parser/Pod.pm
+++ b/server/lib/PLS/Parser/Pod.pm
@@ -293,7 +293,7 @@ sub get_clean_inc
 
     unshift @include, @{$PLS::Server::State::CONFIG->{inc}} if (ref $PLS::Server::State::CONFIG->{inc} eq 'ARRAY');
     my $index = PLS::Parser::Index->new();
-    unshift @include, @{$index->{workspace_folders}};
+    unshift @include, @{PLS::Parser::Index->new->workspace_folders};
 
     return \@include;
 } ## end sub get_clean_inc

--- a/server/lib/PLS/Parser/Pod.pm
+++ b/server/lib/PLS/Parser/Pod.pm
@@ -10,6 +10,7 @@ use Pod::Markdown;
 use Pod::Simple::Search;
 use Symbol qw(gensym);
 
+use PLS::Parser::Index;
 use PLS::Server::State;
 
 =head1 NAME
@@ -291,7 +292,9 @@ sub get_clean_inc
     } ## end if (my $pid = open my ...)
 
     unshift @include, @{$PLS::Server::State::CONFIG->{inc}} if (ref $PLS::Server::State::CONFIG->{inc} eq 'ARRAY');
-    unshift @include, $PLS::Server::State::ROOT_PATH        if (length $PLS::Server::State::ROOT_PATH);
+    my $index = PLS::Parser::Index->new();
+    unshift @include, @{$index->{workspace_folders}};
+
     return \@include;
 } ## end sub get_clean_inc
 

--- a/server/lib/PLS/Server/Method/Workspace.pm
+++ b/server/lib/PLS/Server/Method/Workspace.pm
@@ -6,6 +6,7 @@ use warnings;
 use PLS::Server::Request::Workspace::Configuration;
 use PLS::Server::Request::Workspace::DidChangeConfiguration;
 use PLS::Server::Request::Workspace::DidChangeWatchedFiles;
+use PLS::Server::Request::Workspace::DidChangeWorkspaceFolders;
 use PLS::Server::Request::Workspace::ExecuteCommand;
 use PLS::Server::Request::Workspace::Symbol;
 
@@ -29,6 +30,10 @@ L<PLS::Server::Request::Workspace::DidChangeConfiguration>
 =item workspace/didChangeWatchedFiles - L<https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeWatchedFiles>
 
 L<PLS::Server::Request::Workspace::DidChangeWatchedFiles>
+
+=item workspace/didChangeWorkspaceFolders - L<https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeWorkspaceFolders>
+
+L<PLS::Server::Request::Workspace::DidChangeWorkspaceFolders>
 
 =item workspace/configuration - L<https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_configuration>
 
@@ -55,6 +60,10 @@ sub get_request
     if ($method eq 'didChangeWatchedFiles')
     {
         return PLS::Server::Request::Workspace::DidChangeWatchedFiles->new($request);
+    }
+    if ($method eq 'didChangeWorkspaceFolders')
+    {
+        return PLS::Server::Request::Workspace::DidChangeWorkspaceFolders->new($request);
     }
     if ($method eq 'configuration')
     {

--- a/server/lib/PLS/Server/Request/Initialize.pm
+++ b/server/lib/PLS/Server/Request/Initialize.pm
@@ -38,7 +38,6 @@ sub service
         $PLS::Server::State::ROOT_PATH = $path->file;
 
         my $index = PLS::Parser::Index->new(root => $path->file);
-        $index->index_files();
 
         PLS::Parser::Document->set_index($index);
     } ## end if (length $root_uri)

--- a/server/lib/PLS/Server/Request/Initialize.pm
+++ b/server/lib/PLS/Server/Request/Initialize.pm
@@ -31,16 +31,14 @@ sub service
     my ($self, $server) = @_;
 
     my $root_uri = $self->{params}{rootUri};
+    my $workspace_folders = $self->{params}{workspaceFolders};
+    $workspace_folders = [] if (ref $workspace_folders ne 'ARRAY');
+    @{$workspace_folders} = map { $_->{uri} } @{$workspace_folders};
+    push @{$workspace_folders}, $root_uri if (not scalar @{$workspace_folders} and length $root_uri);
+    @{$workspace_folders} = map { URI->new($_)->file } @{$workspace_folders};
 
-    if (length $root_uri)
-    {
-        my $path = URI->new($root_uri);
-        $PLS::Server::State::ROOT_PATH = $path->file;
-
-        my $index = PLS::Parser::Index->new(root => $path->file);
-
-        PLS::Parser::Document->set_index($index);
-    } ## end if (length $root_uri)
+    # Create and cache index object
+    PLS::Parser::Index->new(workspace_folders => $workspace_folders);
 
     if (length $self->{params}{processId})
     {

--- a/server/lib/PLS/Server/Request/Initialize.pm
+++ b/server/lib/PLS/Server/Request/Initialize.pm
@@ -30,7 +30,7 @@ sub service
 {
     my ($self, $server) = @_;
 
-    my $root_uri = $self->{params}{rootUri};
+    my $root_uri          = $self->{params}{rootUri};
     my $workspace_folders = $self->{params}{workspaceFolders};
     $workspace_folders = [] if (ref $workspace_folders ne 'ARRAY');
     @{$workspace_folders} = map { $_->{uri} } @{$workspace_folders};

--- a/server/lib/PLS/Server/Request/Initialized.pm
+++ b/server/lib/PLS/Server/Request/Initialized.pm
@@ -8,6 +8,7 @@ use parent 'PLS::Server::Request';
 use PLS::Server::State;
 use PLS::Server::Request::Workspace::Configuration;
 use PLS::Server::Request::Client::RegisterCapability;
+use PLS::Parser::Document;
 
 =head1 NAME
 
@@ -51,6 +52,9 @@ sub service
     } ## end if (length $PLS::Server::State::ROOT_PATH...)
 
     $server->send_server_request(PLS::Server::Request::Client::RegisterCapability->new(\@capabilities));
+
+    my $index = PLS::Parser::Document->get_index();
+    $index->index_files();
 
     return;
 } ## end sub service

--- a/server/lib/PLS/Server/Request/Initialized.pm
+++ b/server/lib/PLS/Server/Request/Initialized.pm
@@ -33,9 +33,11 @@ sub service
     # request that we receive a notification any time configuration changes
     my @capabilities = ({id => 'did-change-configuration', method => 'workspace/didChangeConfiguration'});
 
-    # if there is a root path, request that we receive a notification every time a file changes,
+    # request that we receive a notification every time a file changes,
     # so that we can reindex it.
-    if (length $PLS::Server::State::ROOT_PATH)
+    my $index = PLS::Parser::Index->new();
+
+    if (scalar @{$index->{workspace_folders}})
     {
         push @capabilities,
           {
@@ -53,7 +55,6 @@ sub service
 
     $server->send_server_request(PLS::Server::Request::Client::RegisterCapability->new(\@capabilities));
 
-    my $index = PLS::Parser::Document->get_index();
     $index->index_files();
 
     return;

--- a/server/lib/PLS/Server/Request/Initialized.pm
+++ b/server/lib/PLS/Server/Request/Initialized.pm
@@ -37,7 +37,7 @@ sub service
     # so that we can reindex it.
     my $index = PLS::Parser::Index->new();
 
-    if (scalar @{$index->{workspace_folders}})
+    if (scalar @{$index->workspace_folders})
     {
         push @capabilities,
           {
@@ -51,10 +51,11 @@ sub service
                                             ]
                                }
           };
-    } ## end if (length $PLS::Server::State::ROOT_PATH...)
+    } ## end if (scalar @{$index->workspace_folders...})
 
     $server->send_server_request(PLS::Server::Request::Client::RegisterCapability->new(\@capabilities));
 
+    # Now is a good time to start indexing files.
     $index->index_files();
 
     return;

--- a/server/lib/PLS/Server/Request/TextDocument/DidChange.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/DidChange.pm
@@ -11,6 +11,7 @@ use IO::Async::Loop;
 use IO::Async::Timer::Countdown;
 
 use PLS::Parser::Document;
+use PLS::Parser::Index;
 use PLS::Server::Request::TextDocument::PublishDiagnostics;
 
 =head1 NAME
@@ -46,7 +47,7 @@ sub service
         $timers{$uri} = IO::Async::Timer::Countdown->new(
             delay     => 2,
             on_expire => sub {
-                my $index = PLS::Parser::Document->get_index();
+                my $index = PLS::Parser::Index->new();
                 $index->index_files(URI->new($self->{params}{textDocument}{uri})->file);
 
                 $server->send_server_request(PLS::Server::Request::TextDocument::PublishDiagnostics->new(uri => $uri, unsaved => 1));

--- a/server/lib/PLS/Server/Request/TextDocument/DidChange.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/DidChange.pm
@@ -40,24 +40,27 @@ sub service
         # If we get another change before the timer goes off, reset the timer.
         # This will allow us to limit the diagnostics to a time one second after the user stopped typing.
         $timers{$uri}->reset();
-    }
+    } ## end if (ref $timers{$uri} ...)
     else
     {
         $timers{$uri} = IO::Async::Timer::Countdown->new(
-            delay => 2,
+            delay     => 2,
             on_expire => sub {
+                my $index = PLS::Parser::Document->get_index();
+                $index->index_files(URI->new($self->{params}{textDocument}{uri})->file);
+
                 $server->send_server_request(PLS::Server::Request::TextDocument::PublishDiagnostics->new(uri => $uri, unsaved => 1));
                 delete $timers{$uri};
             },
             remove_on_expire => 1
-        );
+                                                        );
 
         my $loop = IO::Async::Loop->new();
         $loop->add($timers{$uri});
         $timers{$uri}->start();
-    }
+    } ## end else [ if (ref $timers{$uri} ...)]
 
     return;
-}
+} ## end sub service
 
 1;

--- a/server/lib/PLS/Server/Request/TextDocument/DidChange.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/DidChange.pm
@@ -48,13 +48,13 @@ sub service
             delay     => 2,
             on_expire => sub {
                 my $index = PLS::Parser::Index->new();
-                $index->index_files(URI->new($self->{params}{textDocument}{uri})->file);
+                $index->index_files(URI->new($uri)->file);
 
                 $server->send_server_request(PLS::Server::Request::TextDocument::PublishDiagnostics->new(uri => $uri, unsaved => 1));
                 delete $timers{$uri};
             },
             remove_on_expire => 1
-                                                        );
+        );
 
         my $loop = IO::Async::Loop->new();
         $loop->add($timers{$uri});

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -134,11 +134,11 @@ sub get_compilation_errors
 
     close $fh;
 
-    my $perl = PLS::Parser::Pod->get_perl_exe();
-    my $inc  = PLS::Parser::Pod->get_clean_inc();
-    my $args = PLS::Parser::Pod->get_perl_args();
-    my @inc  = map { "-I$_" } @{$inc // []};
-    my $index = PLS::Parser::Index->new();
+    my $perl             = PLS::Parser::Pod->get_perl_exe();
+    my $inc              = PLS::Parser::Pod->get_clean_inc();
+    my $args             = PLS::Parser::Pod->get_perl_args();
+    my @inc              = map { "-I$_" } @{$inc // []};
+    my $index            = PLS::Parser::Index->new();
     my $workspace_folder = List::Util::first { path($_)->subsumes($path) } @{$index->{workspace_folders}};
     $workspace_folder = $index->{workspace_folders}[0] unless (length $workspace_folder);
     my $new_cwd = $PLS::Server::State::CONFIG->{cwd} // '';
@@ -151,7 +151,7 @@ sub get_compilation_errors
 
     my $proc = IO::Async::Process->new(
         command => [$perl, @inc, '-c', $path, @{$args}],
-        setup => \@setup,
+        setup   => \@setup,
         stderr  => {
             on_read => sub {
                 my ($stream, $buffref, $eof) = @_;

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -144,13 +144,14 @@ sub get_compilation_errors
     my $new_cwd = $PLS::Server::State::CONFIG->{cwd} // '';
     $new_cwd =~ s/\$ROOT_PATH/$workspace_folder/;
 
+    my @setup;
+    push @setup, (chdir => $new_cwd) if (length $new_cwd and -d $new_cwd);
+
     my @diagnostics;
 
     my $proc = IO::Async::Process->new(
         command => [$perl, @inc, '-c', $path, @{$args}],
-        setup => [
-            (length $new_cwd and -d $new_cwd ? (chdir => $new_cwd) : ())
-        ],
+        setup => \@setup,
         stderr  => {
             on_read => sub {
                 my ($stream, $buffref, $eof) = @_;

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -139,8 +139,8 @@ sub get_compilation_errors
     my $args             = PLS::Parser::Pod->get_perl_args();
     my @inc              = map { "-I$_" } @{$inc // []};
     my $index            = PLS::Parser::Index->new();
-    my $workspace_folder = List::Util::first { path($_)->subsumes($path) } @{$index->{workspace_folders}};
-    $workspace_folder = $index->{workspace_folders}[0] unless (length $workspace_folder);
+    my $workspace_folder = List::Util::first { path($_)->subsumes($path) } @{$index->workspace_folders};
+    ($workspace_folder) = @{$index->workspace_folders} unless (length $workspace_folder);
     my $new_cwd = $PLS::Server::State::CONFIG->{cwd} // '';
     $new_cwd =~ s/\$ROOT_PATH/$workspace_folder/;
 

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -13,6 +13,7 @@ use File::Temp;
 use IO::Async::Function;
 use IO::Async::Loop;
 use IO::Async::Process;
+use Path::Tiny;
 use Perl::Critic;
 use PPI;
 use URI;
@@ -137,11 +138,18 @@ sub get_compilation_errors
     my $inc  = PLS::Parser::Pod->get_clean_inc();
     my $args = PLS::Parser::Pod->get_perl_args();
     my @inc  = map { "-I$_" } @{$inc // []};
+    my $index = PLS::Parser::Index->new();
+    my $workspace_folder = List::Util::first { path($_)->subsumes($path) } @{$index->{workspace_folders}};
+    my $new_cwd = $PLS::Server::State::CONFIG->{cwd} // '';
+    $new_cwd =~ s/\$ROOT_PATH/$workspace_folder/;
 
     my @diagnostics;
 
     my $proc = IO::Async::Process->new(
         command => [$perl, @inc, '-c', $path, @{$args}],
+        setup => [
+            (length $new_cwd and -d $new_cwd ? (chdir => $new_cwd) : ())
+        ],
         stderr  => {
             on_read => sub {
                 my ($stream, $buffref, $eof) = @_;

--- a/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
+++ b/server/lib/PLS/Server/Request/TextDocument/PublishDiagnostics.pm
@@ -140,6 +140,7 @@ sub get_compilation_errors
     my @inc  = map { "-I$_" } @{$inc // []};
     my $index = PLS::Parser::Index->new();
     my $workspace_folder = List::Util::first { path($_)->subsumes($path) } @{$index->{workspace_folders}};
+    $workspace_folder = $index->{workspace_folders}[0] unless (length $workspace_folder);
     my $new_cwd = $PLS::Server::State::CONFIG->{cwd} // '';
     $new_cwd =~ s/\$ROOT_PATH/$workspace_folder/;
 

--- a/server/lib/PLS/Server/Request/Workspace/Configuration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/Configuration.pm
@@ -59,12 +59,12 @@ sub handle_response
     {
         foreach my $inc (@{$config->{inc}})
         {
-            foreach my $folder (@{$index->{workspace_folders}})
+            foreach my $folder (@{$index->workspace_folders})
             {
                 my $interpolated = $inc =~ s/\$ROOT_PATH/$folder/gr;
                 push @inc, $interpolated;
             }
-        }
+        } ## end foreach my $inc (@{$config->...})
 
         $config->{inc} = [List::Util::uniq sort @inc];
     } ## end if (exists $config->{inc...})

--- a/server/lib/PLS/Server/Request/Workspace/Configuration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/Configuration.pm
@@ -69,13 +69,6 @@ sub handle_response
         $config->{inc} = [List::Util::uniq sort @inc];
     } ## end if (exists $config->{inc...})
 
-    # Can only do a single CWD - just use the first workspace folder.
-    if (exists $config->{cwd} and length $config->{cwd})
-    {
-        $config->{cwd} =~ s/\$ROOT_PATH/$index->{workspace_folders}[0]/g;
-        chdir $config->{cwd};
-    }
-
     if (exists $config->{syntax}{perl} and length $config->{syntax}{perl})
     {
         PLS::Parser::Pod->set_perl_exe($config->{syntax}{perl});

--- a/server/lib/PLS/Server/Request/Workspace/Configuration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/Configuration.pm
@@ -74,9 +74,9 @@ sub handle_response
         PLS::Parser::Pod->set_perl_exe($config->{syntax}{perl});
     }
 
-    if (exists $config->{syntax}{perlargs} and ref $config->{syntax}{perlargs} eq 'ARRAY' and scalar @{$config->{syntax}{perlargs}})
+    if (exists $config->{syntax}{args} and ref $config->{syntax}{args} eq 'ARRAY' and scalar @{$config->{syntax}{args}})
     {
-        PLS::Parser::Pod->set_perl_args($config->{syntax}{perlargs});
+        PLS::Parser::Pod->set_perl_args($config->{syntax}{args});
     }
 
     $PLS::Server::State::CONFIG = $config;

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeConfiguration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeConfiguration.pm
@@ -25,10 +25,7 @@ sub service
 {
     my ($self, $server) = @_;
 
-    my $index = PLS::Parser::Document->get_index();
-
     $server->send_server_request(PLS::Server::Request::Workspace::Configuration->new());
-    $index->index_files();
 }
 
 1;

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeConfiguration.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeConfiguration.pm
@@ -25,7 +25,10 @@ sub service
 {
     my ($self, $server) = @_;
 
+    my $index = PLS::Parser::Document->get_index();
+
     $server->send_server_request(PLS::Server::Request::Workspace::Configuration->new());
+    $index->index_files();
 }
 
 1;

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
@@ -8,7 +8,7 @@ use parent 'PLS::Server::Request';
 use List::Util qw(any uniq);
 use Path::Tiny;
 
-use PLS::Parser::Document;
+use PLS::Parser::Index;
 use PLS::Server::Request::TextDocument::PublishDiagnostics;
 
 =head1 NAME
@@ -30,8 +30,7 @@ sub service
 
     return if (ref $self->{params}{changes} ne 'ARRAY');
 
-    my $index = PLS::Parser::Document->get_index();
-    return if (ref $index ne 'PLS::Parser::Index');
+    my $index = PLS::Parser::Index->new();
 
     my @changed_files;
     my $any_deletes;

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
@@ -41,6 +41,7 @@ sub service
         my $file = URI->new($change->{uri});
 
         next unless (ref $file eq 'URI::file');
+        next if ($file->file =~ /\/\.pls-tmp-.*$/);
 
         if ($change->{type} == 3)
         {

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeWatchedFiles.pm
@@ -40,7 +40,7 @@ sub service
         my $file = URI->new($change->{uri});
 
         next unless (ref $file eq 'URI::file');
-        next if ($file->file =~ /\/\.pls-tmp-.*$/);
+        next if ($file->file =~ /\/\.pls-tmp-[^\/]*$/);
 
         if ($change->{type} == 3)
         {

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
@@ -15,6 +15,8 @@ PLS::Server::Request::Workspace::DidChangeWorkspaceFolders
 
 =head1 DESCRIPTION
 
+This is a notification from the client to the server that
+workspace folders were added or removed.
 
 =cut
 

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
@@ -1,0 +1,45 @@
+package PLS::Server::Request::Workspace::DidChangeWorkspaceFolders;
+
+use strict;
+use warnings;
+
+use parent 'PLS::Server::Request';
+
+use URI;
+
+use PLS::Parser::Index;
+
+=head1 NAME
+
+PLS::Server::Request::Workspace::DidChangeWorkspaceFolders
+
+=head1 DESCRIPTION
+
+
+=cut
+
+sub service
+{
+    my ($self) = @_;
+
+    my $added = $self->{params}{added};
+    my $removed = $self->{params}{removed}; 
+
+    my $index = PLS::Parser::Index->new();
+
+    foreach my $folder (@{$removed})
+    {
+        my $path = URI->new($folder->{uri})->file;
+        $index->deindex_workspace($path);
+    }
+
+    foreach my $folder (@{$added})
+    {
+        my $path = URI->new($folder->{uri})->file;
+        $index->index_workspace($path);
+    }
+
+    return;
+}
+
+1;

--- a/server/lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
+++ b/server/lib/PLS/Server/Request/Workspace/DidChangeWorkspaceFolders.pm
@@ -22,8 +22,8 @@ sub service
 {
     my ($self) = @_;
 
-    my $added = $self->{params}{added};
-    my $removed = $self->{params}{removed}; 
+    my $added   = $self->{params}{added};
+    my $removed = $self->{params}{removed};
 
     my $index = PLS::Parser::Index->new();
 
@@ -40,6 +40,6 @@ sub service
     }
 
     return;
-}
+} ## end sub service
 
 1;

--- a/server/lib/PLS/Server/Response/Completion.pm
+++ b/server/lib/PLS/Server/Response/Completion.pm
@@ -68,6 +68,7 @@ sub new
         {
             $full_text = $document->get_full_text();
             push @results, @{get_subroutines($document, $filter, $full_text)};
+            push @results, @{get_constants($document, $filter, $full_text)};
             push @results, @{get_keywords()} unless $arrow;
         } ## end unless (scalar @{$functions...})
 

--- a/server/lib/PLS/Server/Response/InitializeResult.pm
+++ b/server/lib/PLS/Server/Response/InitializeResult.pm
@@ -52,7 +52,13 @@ sub new
                                                     'perl.sortImports'
                                                 ]
                                             },
-                                            workspaceSymbolProvider => JSON::PP::true
+                                            workspaceSymbolProvider => JSON::PP::true,
+                                            workspace => {
+                                                            workspaceFolders => {
+                                                                                    supported => JSON::PP::true,
+                                                                                    changeNotifications => JSON::PP::true
+                                                                                }
+                                                         }
                                            }
                           }
                );

--- a/server/lib/PLS/Server/Response/InitializeResult.pm
+++ b/server/lib/PLS/Server/Response/InitializeResult.pm
@@ -39,7 +39,7 @@ sub new
                                             textDocumentSync => {
                                                                  openClose => JSON::PP::true,
                                                                  change    => 2,
-                                                                 save => JSON::PP::true,
+                                                                 save      => JSON::PP::true,
                                                                 },
                                             documentFormattingProvider      => JSON::PP::true,
                                             documentRangeFormattingProvider => JSON::PP::true,
@@ -48,16 +48,14 @@ sub new
                                                                    resolveProvider   => JSON::PP::true,
                                                                   },
                                             executeCommandProvider => {
-                                                commands => [
-                                                    'perl.sortImports'
-                                                ]
-                                            },
+                                                                       commands => ['perl.sortImports']
+                                                                      },
                                             workspaceSymbolProvider => JSON::PP::true,
-                                            workspace => {
-                                                            workspaceFolders => {
-                                                                                    supported => JSON::PP::true,
-                                                                                    changeNotifications => JSON::PP::true
-                                                                                }
+                                            workspace               => {
+                                                          workspaceFolders => {
+                                                                               supported           => JSON::PP::true,
+                                                                               changeNotifications => JSON::PP::true
+                                                                              }
                                                          }
                                            }
                           }
@@ -72,6 +70,6 @@ sub serialize
 
     $PLS::Server::State::INITIALIZED = 1;
     return $self->SUPER::serialize();
-}
+} ## end sub serialize
 
 1;

--- a/server/lib/PLS/Server/Response/Resolve.pm
+++ b/server/lib/PLS/Server/Response/Resolve.pm
@@ -29,7 +29,7 @@ sub new
     bless $self, $class;
 
     my $index = PLS::Parser::Index->new();
-    my $kind = $request->{params}{kind};
+    my $kind  = $request->{params}{kind};
 
     if ($kind == 7)
     {
@@ -75,14 +75,14 @@ sub new
     elsif ($kind == 14)
     {
         my $pod = PLS::Parser::Pod::Builtin->new(function => $request->{params}{label});
-        my $ok = $pod->find();
+        my $ok  = $pod->find();
 
         if ($ok)
         {
             $self->{result} = $request->{params};
             $self->{result}{documentation} = {kind => 'markdown', value => ${$pod->{markdown}}};
         }
-    }
+    } ## end elsif ($kind == 14)
 
     return $self;
 } ## end sub new

--- a/server/lib/PLS/Server/Response/Resolve.pm
+++ b/server/lib/PLS/Server/Response/Resolve.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'PLS::Server::Response';
 
-use PLS::Parser::Document;
+use PLS::Parser::Index;
 use PLS::Parser::Pod::Package;
 use PLS::Parser::Pod::Subroutine;
 use PLS::Parser::Pod::Builtin;
@@ -28,9 +28,7 @@ sub new
     my $self = {id => $request->{id}, result => undef};
     bless $self, $class;
 
-    my $index = PLS::Parser::Document->get_index();
-    return $self unless (ref $index eq 'PLS::Parser::Index');
-
+    my $index = PLS::Parser::Index->new();
     my $kind = $request->{params}{kind};
 
     if ($kind == 7)

--- a/server/lib/PLS/Server/Response/WorkspaceSymbols.pm
+++ b/server/lib/PLS/Server/Response/WorkspaceSymbols.pm
@@ -13,7 +13,7 @@ sub new
 
     my $query = $request->{params}{query};
 
-    my $index = PLS::Parser::Document->get_index()->index();
+    my $index = PLS::Parser::Document->get_index()->{cache};
     my @symbols;
 
     foreach my $name (keys %{$index->{subs}})
@@ -24,20 +24,11 @@ sub new
 
         foreach my $sub (@{$refs})
         {
-            my $line_end = $sub->{location}{column_number} + (length $name);
-            $line_end += length 'sub ' unless ($sub->{constant});
-
             push @symbols,
               {
                 name     => $name,
                 kind     => 12,
-                location => {
-                             uri   => URI::file->new($sub->{file})->as_string(),
-                             range => {
-                                       start => {line => $sub->{location}{line_number}, character => $sub->{location}{column_number}},
-                                       end   => {line => $sub->{location}{line_number}, character => $line_end}
-                                      }
-                            }
+                location => $sub
               };
         } ## end foreach my $sub (@{$refs})
     } ## end foreach my $name (keys %{$index...})
@@ -50,20 +41,11 @@ sub new
 
         foreach my $package (@{$refs})
         {
-            my $line_end = $package->{location}{column_number} + (length $name);
-            $line_end += length 'package ';
-
             push @symbols,
               {
                 name     => $name,
                 kind     => 4,
-                location => {
-                             uri   => URI::file->new($package->{file})->as_string(),
-                             range => {
-                                       start => {line => $package->{location}{line_number}, character => $package->{location}{column_number}},
-                                       end   => {line => $package->{location}{line_number}, character => $line_end}
-                                      }
-                            }
+                location => $package
               };
         } ## end foreach my $package (@{$refs...})
     } ## end foreach my $name (keys %{$index...})

--- a/server/lib/PLS/Server/Response/WorkspaceSymbols.pm
+++ b/server/lib/PLS/Server/Response/WorkspaceSymbols.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'PLS::Server::Response';
 
-use PLS::Parser::Document;
+use PLS::Parser::Index;
 
 sub new
 {
@@ -13,7 +13,8 @@ sub new
 
     my $query = $request->{params}{query};
 
-    my $index = PLS::Parser::Document->get_index()->{cache};
+    my $index = PLS::Parser::Index->new();
+    $index = $index->{cache};
     my @symbols;
 
     foreach my $name (keys %{$index->{subs}})

--- a/server/lib/PLS/Server/Response/WorkspaceSymbols.pm
+++ b/server/lib/PLS/Server/Response/WorkspaceSymbols.pm
@@ -14,14 +14,13 @@ sub new
     my $query = $request->{params}{query};
 
     my $index = PLS::Parser::Index->new();
-    $index = $index->{cache};
     my @symbols;
 
-    foreach my $name (keys %{$index->{subs}})
+    foreach my $name (keys %{$index->subs})
     {
         next if ($name !~ /\Q$query\E/i);
 
-        my $refs = $index->{subs}{$name};
+        my $refs = $index->subs->{$name};
 
         foreach my $sub (@{$refs})
         {
@@ -34,11 +33,11 @@ sub new
         } ## end foreach my $sub (@{$refs})
     } ## end foreach my $name (keys %{$index...})
 
-    foreach my $name (keys %{$index->{packages}})
+    foreach my $name (keys %{$index->packages})
     {
         next if ($name !~ /\Q$query\E/i);
 
-        my $refs = $index->{packages}{$name};
+        my $refs = $index->packages->{$name};
 
         foreach my $package (@{$refs})
         {

--- a/server/t/01server.t
+++ b/server/t/01server.t
@@ -127,7 +127,7 @@ subtest 'server not initialized' => sub {
 };
 
 subtest 'initialize server' => sub {
-    plan tests => 16;
+    plan tests => 15;
 
     my $comm     = t::Communicate->new();
     my $response = initialize_server($comm);
@@ -138,7 +138,7 @@ subtest 'initialize server' => sub {
 
     cmp_ok(scalar keys %{$response->{result}}, '==', 1, 'result has 1 key');
     is(ref $response->{result}{capabilities}, 'HASH', 'response capabilities is json object');
-    cmp_ok(scalar keys %{$response->{result}{capabilities}}, '==', 10, 'capabilities has 10 keys');
+    cmp_ok(scalar keys %{$response->{result}{capabilities}}, '==', 11, 'capabilities has 11 keys');
 
     my $capabilities = $response->{result}{capabilities};
 
@@ -152,13 +152,6 @@ subtest 'initialize server' => sub {
     is_deeply($capabilities->{completionProvider},     {triggerCharacters => ['>', ':', '$', '@', '%'], resolveProvider => JSON::PP::true}, 'server is completion provider');
     is_deeply($capabilities->{executeCommandProvider}, {commands          => ['perl.sortImports']},                                         'server can execute commands');
     ok($capabilities->{workspaceSymbolProvider}, 'server is workspace symbol provider');
-
-    chomp(my $error = $comm->recv_err());
-  SKIP:
-    {
-        skip('timing issue - indexing not logged yet', 1) unless (length $error);
-        like($error, qr/Indexing/, 'indexing logged');
-    }
 };
 
 subtest 'initial requests' => sub {

--- a/server/t/01server.t
+++ b/server/t/01server.t
@@ -85,7 +85,6 @@ sub valid_notification
     return 0 if (exists $packet->{params} and ref $packet->{params} ne 'HASH' and ref $packet->{params} ne 'ARRAY');
     return 1;
 } ## end sub valid_notification
-use Data::Dumper;
 
 sub initialize_server
 {

--- a/server/t/02document-new.t
+++ b/server/t/02document-new.t
@@ -27,8 +27,10 @@ subtest 'new with uri' => sub {
     subtest 'new with line' => sub {
         plan tests => 5;
 
-        $doc = PLS::Parser::Document->new(uri => $uri->as_string, line => 5);
-        $index->{cache} = {};
+        $doc               = PLS::Parser::Document->new(uri => $uri->as_string, line => 5);
+        $index->{subs}     = {};
+        $index->{packages} = {};
+        $index->{files}    = {};
         isa_ok($doc,             'PLS::Parser::Document');
         isa_ok($doc->{document}, 'PPI::Document');
         isa_ok($doc->{index},    'PLS::Parser::Index');
@@ -44,7 +46,9 @@ subtest 'new with path' => sub {
     plan tests => 3;
 
     my $uri = URI::file->new(File::Spec->catfile($FindBin::RealBin, $FindBin::RealScript));
-    $index->{cache} = {};
+    $index->{subs}     = {};
+    $index->{packages} = {};
+    $index->{files}    = {};
     my $doc = PLS::Parser::Document->new(path => $uri->file);
 
     isa_ok($doc,             'PLS::Parser::Document');

--- a/server/t/02document-new.t
+++ b/server/t/02document-new.t
@@ -12,7 +12,7 @@ use URI;
 use PLS::Parser::Document;
 use PLS::Server::State;
 
-local $PLS::Server::State::ROOT_PATH = $FindBin::RealBin;
+my $index = PLS::Parser::Index->new(workspace_folders => [$FindBin::RealBin]);
 
 subtest 'new with uri' => sub {
     plan tests => 4;
@@ -27,8 +27,8 @@ subtest 'new with uri' => sub {
     subtest 'new with line' => sub {
         plan tests => 5;
 
-        PLS::Parser::Document->set_index(undef);
         $doc = PLS::Parser::Document->new(uri => $uri->as_string, line => 5);
+        $index->{cache} = {};
         isa_ok($doc,             'PLS::Parser::Document');
         isa_ok($doc->{document}, 'PPI::Document');
         isa_ok($doc->{index},    'PLS::Parser::Index');
@@ -44,7 +44,7 @@ subtest 'new with path' => sub {
     plan tests => 3;
 
     my $uri = URI::file->new(File::Spec->catfile($FindBin::RealBin, $FindBin::RealScript));
-    PLS::Parser::Document->set_index(undef);
+    $index->{cache} = {};
     my $doc = PLS::Parser::Document->new(path => $uri->file);
 
     isa_ok($doc,             'PLS::Parser::Document');

--- a/server/t/03document-find_word_under_cursor.t
+++ b/server/t/03document-find_word_under_cursor.t
@@ -14,7 +14,8 @@ use PLS::Server::State;
 
 my $text = do { local $/; <DATA> };
 
-local $PLS::Server::State::ROOT_PATH = $FindBin::RealBin;
+# Cache workspace folders
+PLS::Parser::Index->new(workspace_folders => [$FindBin::RealBin]);
 
 my $uri = URI::file->new(File::Spec->catfile($FindBin::RealBin, File::Basename::basename($0)));
 PLS::Parser::Document->open_file(uri => $uri->as_string, text => $text, languageId => 'perl');


### PR DESCRIPTION
This merge request replaces the index file with a faster indexing operation that occurs at startup.

* Uses PPR instead of PPI for parsing out subroutines and packages
* Because it no longer indexes to a file, we have the freedom to add support for multiple workspace folders
* Looks at subroutine signatures for parameters (instead of just `my (...) = @_`)
* Files are reindexed on change, not just when they are saved
* Indexing function is appropriately multi-threaded - instead of passing all the files to be indexed to a single IO::Async::Function worker job, allow IO::Async::Function to pass each file to a free worker.

Unrelated changes included in this MR:

* perl.syntax.perlargs renamed to perl.syntax.args and description updated