### PR TITLE
Remove process ID check

### DIFF
--- a/server/lib/PLS/Server.pm
+++ b/server/lib/PLS/Server.pm
@@ -9,7 +9,6 @@ use Future::Utils;
 use IO::Async::Loop;
 use IO::Async::Signal;
 use IO::Async::Stream;
-use IO::Async::Timer::Periodic;
 use IO::Handle;
 use Scalar::Util qw(blessed);
 
@@ -239,24 +238,6 @@ sub handle_server_response
     $self->send_message($response);
     return;
 } ## end sub handle_server_response
-
-sub monitor_client_process
-{
-    my ($self, $pid) = @_;
-
-    my $timer = IO::Async::Timer::Periodic->new(
-        interval => 30,
-        on_tick  => sub {
-            return if (kill 'ZERO', $pid);
-            $self->stop(1);
-        }
-    );
-    $self->{loop}->add($timer);
-
-    $timer->start();
-
-    return;
-} ## end sub monitor_client_process
 
 sub stop
 {

--- a/server/lib/PLS/Server/Request/Initialize.pm
+++ b/server/lib/PLS/Server/Request/Initialize.pm
@@ -28,7 +28,7 @@ some initialization for itself and returns its capabilities.
 
 sub service
 {
-    my ($self, $server) = @_;
+    my ($self) = @_;
 
     my $root_uri          = $self->{params}{rootUri};
     my $workspace_folders = $self->{params}{workspaceFolders};
@@ -39,11 +39,6 @@ sub service
 
     # Create and cache index object
     PLS::Parser::Index->new(workspace_folders => $workspace_folders);
-
-    if (length $self->{params}{processId})
-    {
-        $server->monitor_client_process($self->{params}{processId});
-    }
 
     $PLS::Server::State::CLIENT_CAPABILITIES = $self->{params}{capabilities};
 


### PR DESCRIPTION
This reverts commit a7cfe2abe6964d237a84f369709e9441f52ac1c4, removing the process ID check. This allows PLS to be run in a separate process space where it can't check if the client process is alive.

Fixes #118