### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ nvim-lspconfig comes with a default configuration for PLS and its name is `perlp
 
 The simplest means of configuring PLS is to place the following somewhere in your Neovim config:
 ```
-require'lspconfig'.perlpls.setup()
+require'lspconfig'.perlpls.setup({})
 ```
 This will set you up with the defaults. It assumes that `pls` is in your $PATH. By default Perl Critic integration will be turned off.
 


### PR DESCRIPTION
I believe that `lspconfig.perlpls.setup()` always expects a table, thus to use it by default config one should put `lspconfig.perlpls.setup({})` (instead of `lspconfig.perlpls.setup()`) to config file.